### PR TITLE
Fix context menu outline

### DIFF
--- a/kstyle/darklyhelper.cpp
+++ b/kstyle/darklyhelper.cpp
@@ -548,6 +548,7 @@ void Helper::renderMenuFrame(QPainter *painter, const QRect &rect, const QColor 
             painter->setBrush(Qt::NoBrush);
             frameRect = strokedRect(frameRect);
             radius += 0.5; // enhance pixel aligment
+            painter->setCompositionMode(QPainter::CompositionMode_SourceOver);
 
             painter->drawRoundedRect(frameRect, radius, radius);
         }


### PR DESCRIPTION
Commit 28bfa2eb957899dca812d204a679400b9ed4449c changed the composition mode to Source when painting transparent context menus. On dark color schemes, there is a transparent outline painted on top of the menu background. The Source mode results in the outline replacing pixels of the background instead being painted on top.

This PR changes the mode to SourceOver (default) before painting the outline, making context menus look like in v0.5.11. It doesn't break menu transparency, because it's changed only for the outline.

![comparison](https://github.com/user-attachments/assets/524b53d7-ddc0-40fa-a59f-2a12a1e9f678)