### PR TITLE
Add setting to use highlight color as selected tab background

### DIFF
--- a/kstyle/config/darklystyleconfig.cpp
+++ b/kstyle/config/darklystyleconfig.cpp
@@ -85,6 +85,7 @@ StyleConfig::StyleConfig(QWidget *parent)
     connect(_tabBarAltStyle, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
     connect(_transparentDolphinView, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
     connect(_cornerRadius, SIGNAL(valueChanged(int)), SLOT(updateChanged()));
+    connect(_tabUseHighlightColor, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
 }
 
 //__________________________________________________________________
@@ -119,6 +120,7 @@ void StyleConfig::save()
     StyleConfigData::setTabBarAltStyle(_tabBarAltStyle->isChecked());
     StyleConfigData::setTransparentDolphinView(_transparentDolphinView->isChecked());
     StyleConfigData::setCornerRadius(_cornerRadius->value());
+    StyleConfigData::setTabUseHighlightColor(_tabUseHighlightColor->isChecked());
 
     StyleConfigData::self()->save();
 
@@ -211,6 +213,8 @@ void StyleConfig::updateChanged()
         modified = true;
     else if (_tabBGColor->color() != StyleConfigData::tabBGColor())
         modified = true;
+    else if (_tabUseHighlightColor->isChecked() != StyleConfigData::tabUseHighlightColor())
+        modified = true;
 
     emit changed(modified);
 }
@@ -252,6 +256,7 @@ void StyleConfig::load()
     _tabBGColor->setColor(StyleConfigData::tabBGColor());
     _transparentDolphinView->setChecked(StyleConfigData::transparentDolphinView());
     _cornerRadius->setValue(StyleConfigData::cornerRadius());
+    _tabUseHighlightColor->setChecked(StyleConfigData::tabUseHighlightColor());
     _versionNumber->setText(DARKLY_VERSION_STRING);
 }
 

--- a/kstyle/config/ui/darklystyleconfig.ui
+++ b/kstyle/config/ui/darklystyleconfig.ui
@@ -51,7 +51,7 @@
        <string>General</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="16" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="label_2">
          <property name="layoutDirection">
           <enum>Qt::LayoutDirection::LeftToRight</enum>
@@ -61,7 +61,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <widget class="QLabel" name="_windowDragLabel">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -80,7 +80,7 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="_cornerRadiusLabel">
          <property name="text">
           <string>Corner radius:</string>
@@ -90,14 +90,14 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0" colspan="3">
+       <item row="2" column="0" colspan="3">
         <widget class="QCheckBox" name="_unifiedTabBarKonsole">
          <property name="text">
           <string>Unify konsole tab bar with header area</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QRadioButton" name="_defaultTabbar">
          <property name="text">
           <string>Default tabbar</string>
@@ -107,7 +107,7 @@
          </property>
         </widget>
        </item>
-       <item row="20" column="3">
+       <item row="21" column="3">
         <widget class="QLabel" name="_versionNumber">
          <property name="text">
           <string/>
@@ -117,7 +117,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
+       <item row="18" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <widget class="QLabel" name="label_3">
@@ -138,21 +138,21 @@
          </item>
         </layout>
        </item>
-       <item row="2" column="0" colspan="5">
+       <item row="3" column="0" colspan="5">
         <widget class="QCheckBox" name="_toolBarDrawItemSeparator">
          <property name="text">
           <string>Draw toolbar item separators</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QCheckBox" name="_widgetDrawShadow">
          <property name="text">
           <string>Draw widget shadow</string>
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <widget class="QSlider" name="_buttonSize">
          <property name="minimum">
           <number>-2</number>
@@ -177,7 +177,7 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QSpinBox" name="_cornerRadius">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -199,7 +199,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QComboBox" name="_windowDragMode">
          <item>
           <property name="text">
@@ -218,7 +218,7 @@
          </item>
         </widget>
        </item>
-       <item row="11" column="3" colspan="2">
+       <item row="12" column="3" colspan="2">
         <spacer name="horizontalSpacer_3">
          <property name="orientation">
           <enum>Qt::Orientation::Horizontal</enum>
@@ -231,7 +231,7 @@
          </property>
         </spacer>
        </item>
-       <item row="12" column="3">
+       <item row="13" column="3">
         <spacer name="horizontalSpacer_5">
          <property name="orientation">
           <enum>Qt::Orientation::Horizontal</enum>
@@ -244,7 +244,7 @@
          </property>
         </spacer>
        </item>
-       <item row="17" column="3">
+       <item row="18" column="3">
         <spacer name="horizontalSpacer_8">
          <property name="orientation">
           <enum>Qt::Orientation::Horizontal</enum>
@@ -257,14 +257,14 @@
          </property>
         </spacer>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QCheckBox" name="_scrollableMenu">
          <property name="text">
           <string>Scrollable popup menu</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QComboBox" name="_mnemonicsMode">
          <item>
           <property name="text">
@@ -283,14 +283,14 @@
          </item>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QRadioButton" name="_tabBarAltStyle">
          <property name="text">
           <string>„TabBarAltStyle”</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="3">
+       <item row="14" column="3">
         <spacer name="horizontalSpacer_6">
          <property name="orientation">
           <enum>Qt::Orientation::Horizontal</enum>
@@ -303,7 +303,7 @@
          </property>
         </spacer>
        </item>
-       <item row="16" column="3">
+       <item row="17" column="3">
         <spacer name="horizontalSpacer_7">
          <property name="orientation">
           <enum>Qt::Orientation::Horizontal</enum>
@@ -316,14 +316,14 @@
          </property>
         </spacer>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QRadioButton" name="_oldTabbar">
          <property name="text">
           <string>Old tabbar</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="0" colspan="5">
+       <item row="4" column="0" colspan="5">
         <widget class="QCheckBox" name="_viewDrawFocusIndicator">
          <property name="text">
           <string>Draw focus indicator in lists</string>
@@ -337,7 +337,14 @@
          </property>
         </widget>
        </item>
-       <item row="19" column="0" colspan="4">
+       <item row="1" column="0" colspan="5">
+        <widget class="QCheckBox" name="_tabUseHighlightColor">
+         <property name="text">
+          <string>Use highlight color as selected tab background</string>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="0" colspan="4">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
@@ -350,7 +357,7 @@
          </property>
         </spacer>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="_mnemonicsLabel">
          <property name="text">
           <string>&amp;Keyboard accelerators visibility:</string>

--- a/kstyle/darkly.kcfg
+++ b/kstyle/darkly.kcfg
@@ -162,6 +162,10 @@
       <default>false</default>
     </entry>
 
+    <entry name="TabUseHighlightColor" type="Bool">
+      <default>false</default>
+    </entry>
+
     <!-- frames -->
     <entry name="TitleWidgetDrawFrame" type="Bool">
       <default>false</default>

--- a/kstyle/darklystyle.cpp
+++ b/kstyle/darklystyle.cpp
@@ -6676,8 +6676,11 @@ bool Style::drawTabBarTabShapeControl(const QStyleOption *option, QPainter *pain
     // tab color
     QColor color;
     if (selected)
-        color = (documentMode && !isQtQuickControl && !hasAlteredBackground(widget)) ? palette.color(QPalette::Window) : _helper->frameBackgroundColor(palette);
-
+        if (StyleConfigData::tabUseHighlightColor()) {
+            color = palette.color(QPalette::Highlight);
+        } else {
+            color = (documentMode && !isQtQuickControl && !hasAlteredBackground(widget)) ? palette.color(QPalette::Window) : _helper->frameBackgroundColor(palette);
+        }
     else {
         const auto normal(_helper->alphaColor(palette.color(QPalette::Shadow), 0.1));
         const auto hover(_helper->alphaColor(_helper->hoverColor(palette), 0.2));
@@ -6982,8 +6985,12 @@ bool Style::drawTabBarTabShapeControl(const QStyleOption *option, QPainter *pain
             _helper->renderBoxShadow(painter, backgroundRect, 0, 1, 6, QColor(0, 0, 0, 100), StyleConfigData::cornerRadius(), true);
             painter->setBrush(color);
             painter->drawRoundedRect(backgroundRect, StyleConfigData::cornerRadius(), StyleConfigData::cornerRadius());
-            painter->setBrush(QColor(255, 255, 255, 20));
-            painter->drawRoundedRect(backgroundRect, StyleConfigData::cornerRadius(), StyleConfigData::cornerRadius());
+
+            // Don't lighten the highlight color
+            if (!StyleConfigData::tabUseHighlightColor()) {
+                painter->setBrush(QColor(255, 255, 255, 20));
+                painter->drawRoundedRect(backgroundRect, StyleConfigData::cornerRadius(), StyleConfigData::cornerRadius());
+            }
         }
 
         painter->setClipRegion(oldRegion);


### PR DESCRIPTION
Since tabs of document mode tab bars can be configured to not touch the tab contents, I think it would be nice if selected tabs of both tab bars could use the highlight color as the background.

This can be toggled in the style settings and is disabled by default.

Disabled:
![disabled](https://github.com/user-attachments/assets/a1c2cf29-ac4a-4061-be31-ff241137518a)

Enabled:
![enabled](https://github.com/user-attachments/assets/1d6b9160-8023-4349-97e2-755c8dc25ab3)

"TabBarAltStyle" looks the same as before, but old tab bar doesn't look very good. Perhaps it would be better to use the highlight color only in non document mode tab bars?
![image](https://github.com/user-attachments/assets/e1404507-8458-46fa-a502-221982a241ba)