### PR TITLE
Add missing dependency for Dolphin capacity status

### DIFF
--- a/.github/workflows/kubuntu.yml
+++ b/.github/workflows/kubuntu.yml
@@ -31,7 +31,7 @@ jobs:
                     libkf5coreaddons-dev libkf5iconthemes-dev gettext qt3d5-dev libkf5kcmutils-dev \
                     qt6-base-dev libkf6coreaddons-dev libkf6colorscheme-dev \
                     libkf6config-dev libkf6guiaddons-dev libkf6i18n-dev libkf6iconthemes-dev \
-                    libkf6windowsystem-dev libkf6kcmutils-dev libkirigami-dev
+                    libkf6windowsystem-dev libkf6kcmutils-dev libkirigami-dev libkf6style-dev
       - name: Extract release tarball
         run: tar xvf ${{ inputs.cache-file-path }}
       - name: Build Darkly


### PR DESCRIPTION
It was also missing from the Kubuntu github workflow.