### PR TITLE
Use the device pixel ratio for icon rendering

### DIFF
--- a/kstyle/darklyhelper.cpp
+++ b/kstyle/darklyhelper.cpp
@@ -1825,14 +1825,19 @@ qreal Helper::devicePixelRatio(const QPixmap &pixmap) const
     return pixmap.devicePixelRatio();
 }
 
-QPixmap Helper::coloredIcon(const QIcon &icon, const QPalette &palette, const QSize &size, QIcon::Mode mode, QIcon::State state)
+QPixmap Helper::coloredIcon(const QIcon &icon, const QPalette &palette, const QSize &size, qreal devicePixelRatio, QIcon::Mode mode, QIcon::State state)
 {
     const QPalette activePalette = KIconLoader::global()->customPalette();
     const bool changePalette = activePalette != palette;
     if (changePalette) {
         KIconLoader::global()->setCustomPalette(palette);
     }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const QPixmap pixmap = icon.pixmap(size, devicePixelRatio, mode, state);
+#else
+    Q_UNUSED(devicePixelRatio);
     const QPixmap pixmap = icon.pixmap(size, mode, state);
+#endif
     if (changePalette) {
         if (activePalette == QPalette()) {
             KIconLoader::global()->resetPalette();

--- a/kstyle/darklyhelper.h
+++ b/kstyle/darklyhelper.h
@@ -425,7 +425,12 @@ public:
     //* return a QRectF with the appropriate size for a rectangle with a pen stroke
     QRectF strokedRect(const QRect &rect, const int penWidth = PenWidth::Frame) const;
 
-    QPixmap coloredIcon(const QIcon &icon, const QPalette &palette, const QSize &size, QIcon::Mode mode = QIcon::Normal, QIcon::State state = QIcon::Off);
+    QPixmap coloredIcon(const QIcon &icon,
+                        const QPalette &palette,
+                        const QSize &size,
+                        qreal devicePixelRatio,
+                        QIcon::Mode mode = QIcon::Normal,
+                        QIcon::State state = QIcon::Off);
 
 protected:
     //* return rounded path in a given rect, with only selected corners rounded, and for a given radius

--- a/kstyle/darklystyle.cpp
+++ b/kstyle/darklystyle.cpp
@@ -1992,9 +1992,11 @@ bool Style::eventFilterCommandLinkButton(QCommandLinkButton *button, QEvent *eve
         if (!button->icon().isNull()) {
             const auto pixmapSize(button->icon().actualSize(button->iconSize()));
             const QRect pixmapRect(QPoint(offset.x(), button->description().isEmpty() ? (button->height() - pixmapSize.height()) / 2 : offset.y()), pixmapSize);
+            const qreal dpr = painter.device() ? painter.device()->devicePixelRatioF() : qApp->devicePixelRatio();
             const QPixmap pixmap(_helper->coloredIcon(button->icon(),
                                                       button->palette(),
                                                       pixmapSize,
+                                                      dpr,
                                                       enabled ? QIcon::Normal : QIcon::Disabled,
                                                       button->isChecked() ? QIcon::On : QIcon::Off));
             drawItemPixmap(&painter, pixmapRect, Qt::AlignCenter, pixmap);
@@ -4581,7 +4583,8 @@ bool Style::drawIndicatorTabClosePrimitive(const QStyleOption *option, QPainter 
     const QSize iconSize(iconWidth, iconWidth);
 
     // get pixmap
-    const QPixmap pixmap(_helper->coloredIcon(icon, option->palette, iconSize, iconMode, iconState));
+    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+    const QPixmap pixmap(_helper->coloredIcon(icon, option->palette, iconSize, dpr, iconMode, iconState));
 
     // render
     drawItemPixmap(painter, option->rect, Qt::AlignCenter, pixmap);
@@ -4900,7 +4903,8 @@ bool Style::drawPushButtonLabelControl(const QStyleOption *option, QPainter *pai
         else
             iconMode = QIcon::Normal;
 
-        const auto pixmap = _helper->coloredIcon(buttonOption->icon, buttonOption->palette, iconSize, iconMode, iconState);
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+        const auto pixmap = _helper->coloredIcon(buttonOption->icon, buttonOption->palette, iconSize, dpr, iconMode, iconState);
         drawItemPixmap(painter, iconRect, Qt::AlignCenter, pixmap);
     }
 
@@ -5034,7 +5038,8 @@ bool Style::drawToolButtonLabelControl(const QStyleOption *option, QPainter *pai
         else
             iconMode = QIcon::Normal;
 
-        const QPixmap pixmap = _helper->coloredIcon(toolButtonOption->icon, toolButtonOption->palette, iconSize, iconMode, iconState);
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+        const QPixmap pixmap = _helper->coloredIcon(toolButtonOption->icon, toolButtonOption->palette, iconSize, dpr, iconMode, iconState);
         drawItemPixmap(painter, iconRect, Qt::AlignCenter, pixmap);
     }
 
@@ -5079,7 +5084,8 @@ bool Style::drawCheckBoxLabelControl(const QStyleOption *option, QPainter *paint
     // render icon
     if (!buttonOption->icon.isNull()) {
         const QIcon::Mode mode(enabled ? QIcon::Normal : QIcon::Disabled);
-        const QPixmap pixmap(_helper->coloredIcon(buttonOption->icon, buttonOption->palette, buttonOption->iconSize, mode));
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+        const QPixmap pixmap(_helper->coloredIcon(buttonOption->icon, buttonOption->palette, buttonOption->iconSize, dpr, mode));
         drawItemPixmap(painter, rect, textFlags, pixmap);
 
         // adjust rect (copied from QCommonStyle)
@@ -5167,7 +5173,8 @@ bool Style::drawComboBoxLabelControl(const QStyleOption *option, QPainter *paint
             else
                 mode = QIcon::Normal;
 
-            const QPixmap pixmap = _helper->coloredIcon(cb->currentIcon, cb->palette, cb->iconSize, mode);
+            const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+            const QPixmap pixmap = _helper->coloredIcon(cb->currentIcon, cb->palette, cb->iconSize, dpr, mode);
             auto iconRect(editRect);
             iconRect.setWidth(cb->iconSize.width() + 4);
             iconRect = alignedRect(cb->direction, Qt::AlignLeft | Qt::AlignVCenter, iconRect.size(), editRect);
@@ -5443,7 +5450,8 @@ bool Style::drawMenuBarItemControl(const QStyleOption *option, QPainter *painter
             iconState = sunken ? QIcon::On : QIcon::Off;
         }
 
-        const auto pixmap = _helper->coloredIcon(menuItemOption->icon, menuItemOption->palette, iconRect.size(), iconMode, iconState);
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+        const auto pixmap = _helper->coloredIcon(menuItemOption->icon, menuItemOption->palette, iconRect.size(), dpr, iconMode, iconState);
         drawItemPixmap(painter, iconRect, Qt::AlignCenter, pixmap);
 
         // render outline
@@ -5613,7 +5621,8 @@ bool Style::drawMenuItemControl(const QStyleOption *option, QPainter *painter, c
 
         // icon state
         const QIcon::State iconState(sunken ? QIcon::On : QIcon::Off);
-        const QPixmap pixmap = _helper->coloredIcon(menuItemOption->icon, menuItemOption->palette, iconRect.size(), mode, iconState);
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+        const QPixmap pixmap = _helper->coloredIcon(menuItemOption->icon, menuItemOption->palette, iconRect.size(), dpr, mode, iconState);
         drawItemPixmap(painter, iconRect, Qt::AlignCenter, pixmap);
     }
 
@@ -7064,7 +7073,8 @@ bool Style::drawToolBoxTabLabelControl(const QStyleOption *option, QPainter *pai
 
         iconRect = visualRect(option, iconRect);
         const QIcon::Mode mode(enabled ? QIcon::Normal : QIcon::Disabled);
-        const QPixmap pixmap(_helper->coloredIcon(toolBoxOption->icon, toolBoxOption->palette, iconRect.size(), mode));
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+        const QPixmap pixmap(_helper->coloredIcon(toolBoxOption->icon, toolBoxOption->palette, iconRect.size(), dpr, mode));
         drawItemPixmap(painter, iconRect, textFlags, pixmap);
     }
 
@@ -7905,7 +7915,8 @@ bool Style::drawTitleBarComplexControl(const QStyleOptionComplex *option, QPaint
         }
 
         // get pixmap and render
-        const QPixmap pixmap = _helper->coloredIcon(icon, option->palette, iconSize, iconMode, iconState);
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+        const QPixmap pixmap = _helper->coloredIcon(icon, option->palette, iconSize, dpr, iconMode, iconState);
         drawItemPixmap(painter, iconRect, Qt::AlignCenter, pixmap);
     }
 


### PR DESCRIPTION
When **fractional scaling is  >100%**. Icons inside buttons, dialog boxes etc are not rendered properly.
This leaves a slight roughness to how the icons are presented as the pixels are visibly more prevalent.

From what I gathered it seems close to the issues seen in #99
Leaving this as WIP for now since we need confirmation.

For example when Darkly is used with the default BreezeDark icons.
![darkly_style](https://github.com/user-attachments/assets/6e5a7438-1651-4ac5-9a21-34126d9d0276)

The pencil icon at the bottom right demonstrates this issue.
![dialog_darkly](https://github.com/user-attachments/assets/eb5911fc-e42c-463b-9c5e-52637f257a9e)

The icon beside the Details button and same issue is seen with OK and Cancel buttons.

These changes are taken directly from Breeze, and are mostly around the introduction of devicePixelRatio which was initially missing from Lightly as such this impacts any derivative forks. See https://doc.qt.io/qt-6/qpaintdevice.html#devicePixelRatio

<b> A relog is required for the change to be applied properly. </b>