### PR TITLE
Handle konsole blur

### DIFF
--- a/kstyle/darklystyle.cpp
+++ b/kstyle/darklystyle.cpp
@@ -340,7 +340,9 @@ void Style::polish(QWidget *widget)
             // konsole handle blur and translucency
             if (_isKonsole) {
                 _translucentWidgets.insert(widget);
-                _blurHelper->registerWidget(widget, _isDolphin);
+                if (widget->palette().color(widget->backgroundRole()).alpha() < 255 || _helper->titleBarColor(true).alphaF() * 100.0 < 100) {
+                    _blurHelper->registerWidget(widget, _isDolphin);
+                }
                 // paint the background in event filter
                 addEventFilter(widget);
                 break;

--- a/kstyle/darklystyle.cpp
+++ b/kstyle/darklystyle.cpp
@@ -337,9 +337,12 @@ void Style::polish(QWidget *widget)
             if (widget->windowFlags().testFlag(Qt::FramelessWindowHint))
                 break;
 
-            // konsole handle blur and translucency itself
+            // konsole handle blur and translucency
             if (_isKonsole) {
                 _translucentWidgets.insert(widget);
+                _blurHelper->registerWidget(widget, _isDolphin);
+                // paint the background in event filter
+                addEventFilter(widget);
                 break;
             }
 


### PR DESCRIPTION
#108 
Register blur since Konsole has issues handling this itself especially for color schemes which support transparency.
Breeze presents the same issue.

This was tested using the Cantadark  and Glassly color schemes.

![konsole](https://github.com/user-attachments/assets/f7fa8f69-15a3-4fbe-93cd-dbaf43066c4e)
