### PR TITLE
Toolbar transparency settings

### DIFF
--- a/kstyle/config/darklystyleconfig.cpp
+++ b/kstyle/config/darklystyleconfig.cpp
@@ -204,7 +204,7 @@ void StyleConfig::updateChanged()
         _menuBarOpacitySpinBox->setValue(_menuBarOpacity->value());
     } else if (_toolBarOpacity->value() != StyleConfigData::toolBarOpacity()) {
         modified = true;
-        _menuBarOpacitySpinBox->setValue(_menuBarOpacity->value());
+        _toolBarOpacitySpinBox->setValue(_toolBarOpacity->value());
     } else if (_kTextEditDrawFrame->isChecked() != StyleConfigData::kTextEditDrawFrame())
         modified = true;
     else if (_tabBarDrawCenteredTabs->isChecked() != StyleConfigData::tabBarDrawCenteredTabs())

--- a/kstyle/config/darklystyleconfig.cpp
+++ b/kstyle/config/darklystyleconfig.cpp
@@ -76,6 +76,10 @@ StyleConfig::StyleConfig(QWidget *parent)
     connect(_menuBarOpacity, SIGNAL(valueChanged(int)), _menuBarOpacitySpinBox, SLOT(setValue(int)));
     connect(_menuBarOpacitySpinBox, SIGNAL(valueChanged(int)), _menuBarOpacity, SLOT(setValue(int)));
 
+    connect(_toolBarOpacity, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
+    connect(_toolBarOpacity, SIGNAL(valueChanged(int)), _toolBarOpacitySpinBox, SLOT(setValue(int)));
+    connect(_toolBarOpacitySpinBox, SIGNAL(valueChanged(int)), _toolBarOpacity, SLOT(setValue(int)));
+
     connect(_kTextEditDrawFrame, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
     connect(_widgetDrawShadow, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
     connect(_scrollableMenu, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
@@ -112,6 +116,7 @@ void StyleConfig::save()
     StyleConfigData::setMenuOpacity(_menuOpacity->value());
     StyleConfigData::setDolphinSidebarOpacity(_sidebarOpacity->value());
     StyleConfigData::setMenuBarOpacity(_menuBarOpacity->value());
+    StyleConfigData::setToolBarOpacity(_toolBarOpacity->value());
     StyleConfigData::setButtonSize(_buttonSize->value());
     StyleConfigData::setKTextEditDrawFrame(_kTextEditDrawFrame->isChecked());
     StyleConfigData::setWidgetDrawShadow(_widgetDrawShadow->isChecked());
@@ -197,6 +202,9 @@ void StyleConfig::updateChanged()
     } else if (_menuBarOpacity->value() != StyleConfigData::menuBarOpacity()) {
         modified = true;
         _menuBarOpacitySpinBox->setValue(_menuBarOpacity->value());
+    } else if (_toolBarOpacity->value() != StyleConfigData::toolBarOpacity()) {
+        modified = true;
+        _menuBarOpacitySpinBox->setValue(_menuBarOpacity->value());
     } else if (_kTextEditDrawFrame->isChecked() != StyleConfigData::kTextEditDrawFrame())
         modified = true;
     else if (_tabBarDrawCenteredTabs->isChecked() != StyleConfigData::tabBarDrawCenteredTabs())
@@ -249,6 +257,8 @@ void StyleConfig::load()
     _tabBarDrawCenteredTabs->setChecked(StyleConfigData::tabBarDrawCenteredTabs());
     _menuBarOpacity->setValue(StyleConfigData::menuBarOpacity());
     _menuBarOpacitySpinBox->setValue(StyleConfigData::menuBarOpacity());
+    _toolBarOpacity->setValue(StyleConfigData::toolBarOpacity());
+    _toolBarOpacitySpinBox->setValue(StyleConfigData::toolBarOpacity());
 
     _buttonSize->setValue(StyleConfigData::buttonSize());
     _kTextEditDrawFrame->setChecked(StyleConfigData::kTextEditDrawFrame());

--- a/kstyle/config/ui/darklystyleconfig.ui
+++ b/kstyle/config/ui/darklystyleconfig.ui
@@ -318,7 +318,7 @@
         <rect>
          <x>10</x>
          <y>0</y>
-         <width>311</width>
+         <width>315</width>
          <height>338</height>
         </rect>
        </property>
@@ -717,151 +717,32 @@
        <string>Transparency</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="1" column="0">
-        <layout class="QFormLayout" name="formLayout_6">
-         <item row="0" column="0">
-          <widget class="QLabel" name="_menuGroupDescription">
-           <property name="text">
-            <string>Menu:     </string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
-           </property>
-           <property name="indent">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_5">
-           <item>
-            <widget class="QSlider" name="_menuOpacity">
-             <property name="toolTip">
-              <string>This changes the menu items transparency</string>
-             </property>
-             <property name="minimum">
-              <number>0</number>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="singleStep">
-              <number>1</number>
-             </property>
-             <property name="pageStep">
-              <number>10</number>
-             </property>
-             <property name="value">
-              <number>100</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="invertedAppearance">
-              <bool>false</bool>
-             </property>
-             <property name="invertedControls">
-              <bool>false</bool>
-             </property>
-             <property name="tickPosition">
-              <enum>QSlider::TickPosition::TicksBelow</enum>
-             </property>
-             <property name="tickInterval">
-              <number>10</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="_menuOpacitySpinBox">
-             <property name="suffix">
-              <string>%</string>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Sidebars:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
-           </property>
-           <property name="indent">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_8">
-           <item>
-            <widget class="QSlider" name="_sidebarOpacity">
-             <property name="toolTip">
-              <string>This changes the Dolphin sidebar transparency</string>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="singleStep">
-              <number>1</number>
-             </property>
-             <property name="pageStep">
-              <number>10</number>
-             </property>
-             <property name="value">
-              <number>100</number>
-             </property>
-             <property name="sliderPosition">
-              <number>100</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="invertedAppearance">
-              <bool>false</bool>
-             </property>
-             <property name="invertedControls">
-              <bool>false</bool>
-             </property>
-             <property name="tickPosition">
-              <enum>QSlider::TickPosition::TicksBelow</enum>
-             </property>
-             <property name="tickInterval">
-              <number>10</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="_sidebarOpacitySpinBox">
-             <property name="suffix">
-              <string>%</string>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="2" column="0">
+       <item row="4" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <item>
           <widget class="QLabel" name="label_7">
            <property name="text">
             <string>Menubar:</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
+            <set>Qt::AlignmentFlag::AlignCenter</set>
            </property>
            <property name="indent">
             <number>5</number>
            </property>
+           <property name="buddy">
+            <cstring>_menuBarOpacity</cstring>
+           </property>
           </widget>
          </item>
-         <item row="2" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_10">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QSlider" name="_menuBarOpacity">
              <property name="toolTip">
@@ -884,17 +765,20 @@
              </property>
             </widget>
            </item>
-           <item>
-            <widget class="QSpinBox" name="_menuBarOpacitySpinBox">
-             <property name="suffix">
-              <string>%</string>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-            </widget>
-           </item>
           </layout>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="_menuBarOpacitySpinBox">
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
@@ -944,6 +828,234 @@
         </layout>
        </item>
        <item row="2" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <item>
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Sidebar:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+           <property name="buddy">
+            <cstring>_sidebarOpacity</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_9">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>10</number>
+           </property>
+           <item>
+            <widget class="QSlider" name="_sidebarOpacity">
+             <property name="toolTip">
+              <string>This changes the Dolphin sidebar transparency</string>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="pageStep">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+             <property name="sliderPosition">
+              <number>100</number>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="invertedAppearance">
+              <bool>false</bool>
+             </property>
+             <property name="invertedControls">
+              <bool>false</bool>
+             </property>
+             <property name="tickPosition">
+              <enum>QSlider::TickPosition::TicksBelow</enum>
+             </property>
+             <property name="tickInterval">
+              <number>10</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="_sidebarOpacitySpinBox">
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="_menuGroupDescription">
+           <property name="text">
+            <string>Menu:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+           <property name="buddy">
+            <cstring>_menuOpacity</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>20</number>
+           </property>
+           <item>
+            <widget class="QSlider" name="_menuOpacity">
+             <property name="toolTip">
+              <string>This changes the menu items transparency</string>
+             </property>
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="pageStep">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="invertedAppearance">
+              <bool>false</bool>
+             </property>
+             <property name="invertedControls">
+              <bool>false</bool>
+             </property>
+             <property name="tickPosition">
+              <enum>QSlider::TickPosition::TicksBelow</enum>
+             </property>
+             <property name="tickInterval">
+              <number>10</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="_menuOpacitySpinBox">
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="6" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QLabel" name="label_8">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Toolbar:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+           <property name="buddy">
+            <cstring>_toolBarOpacity</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>10</number>
+           </property>
+           <item>
+            <widget class="QSlider" name="_toolBarOpacity">
+             <property name="toolTip">
+              <string>This only works on color schemes which support transparency</string>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="tickPosition">
+              <enum>QSlider::TickPosition::TicksBelow</enum>
+             </property>
+             <property name="tickInterval">
+              <number>10</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="_toolBarOpacitySpinBox">
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="7" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>

--- a/kstyle/darkly.kcfg
+++ b/kstyle/darkly.kcfg
@@ -267,6 +267,10 @@
       <default>100</default>
     </entry>
 
+    <entry name="ToolBarOpacity" type="Int">
+        <default>100</default>
+    </entry>
+
     <entry name="AdjustToDarkThemes" type="Bool">
       <default>false</default>
     </entry>

--- a/kstyle/darklystyle.cpp
+++ b/kstyle/darklystyle.cpp
@@ -5231,7 +5231,8 @@ bool Style::drawMenuBarEmptyAreaControl(const QStyleOption *option, QPainter *pa
             background.setAlphaF(opacity);
             painter->fillRect(rect, background);
         } else if (StyleConfigData::menuBarOpacity() == 0) {
-            background.setAlphaF(_helper->titleBarColor(windowActive).alphaF());
+            opacity = 0.0;
+            background.setAlphaF(opacity);
             painter->fillRect(rect, background);
         } else if (StyleConfigData::menuBarOpacity() < 100 && StyleConfigData::menuBarOpacity() > 0) {
             // lower the opacity
@@ -5320,8 +5321,8 @@ bool Style::drawMenuBarItemControl(const QStyleOption *option, QPainter *painter
             background.setAlphaF(opacity);
             painter->fillRect(rect, background);
         } else if (StyleConfigData::menuBarOpacity() == 0) {
-            // use the same titlebar color
-            background.setAlphaF(_helper->titleBarColor(windowActive).alphaF());
+            opacity = 0.0;
+            background.setAlphaF(opacity);
             painter->fillRect(rect, background);
         } else if (StyleConfigData::menuBarOpacity() < 100 && StyleConfigData::menuBarOpacity() > 0) {
             // lower the opacity
@@ -5734,15 +5735,33 @@ bool Style::drawToolBarBackgroundControl(const QStyleOption *option, QPainter *p
     }
 
     // qDebug() << _blurHelper->_sregisteredWidgets;
-    const int opacity = _helper->titleBarColor(windowActive).alphaF() * 100.0;
-
-    painter->setPen(Qt::NoPen);
-
-    _helper->renderTransparentArea(painter, rect);
+    float opacity = 0.0;
 
     // paint background
     QColor backgroundColor = palette.color(QPalette::Window);
-    if (sideToolbarDolphin) {
+
+    painter->setPen(Qt::NoPen);
+
+    if (StyleConfigData::toolBarOpacity() == 100) {
+        // opacity is at 100%
+        opacity = 1.0;
+        backgroundColor.setAlphaF(opacity);
+        painter->fillRect(rect, backgroundColor);
+    } else if (StyleConfigData::toolBarOpacity() == 0) {
+        // use the same titlebar color
+        _helper->renderTransparentArea(painter, rect);
+        opacity = 0.0;
+        backgroundColor.setAlphaF(opacity);
+        painter->fillRect(rect, backgroundColor);
+    } else if (StyleConfigData::toolBarOpacity() < 100 && StyleConfigData::toolBarOpacity() > 0) {
+        // lower the opacity
+        _helper->renderTransparentArea(painter, rect);
+        opacity = StyleConfigData::toolBarOpacity() / 100.0;
+        backgroundColor.setAlphaF(opacity);
+        painter->fillRect(rect, backgroundColor);
+    }
+
+    if (sideToolbarDolphin && _isDolphin) {
         backgroundColor.setAlphaF(StyleConfigData::dolphinSidebarOpacity() / 100.0 - 0.15);
         painter->fillRect(rect, backgroundColor);
 
@@ -5765,9 +5784,6 @@ bool Style::drawToolBarBackgroundControl(const QStyleOption *option, QPainter *p
         painter->drawLine(rect.topLeft() + QPoint(0, 3), rect.topRight() + QPoint(0, 3));
 
         return true;
-    } else {
-        backgroundColor.setAlphaF(opacity / 100.0);
-        painter->fillRect(rect, backgroundColor);
     }
 
     if (StyleConfigData::toolBarDrawSeparator() && !_isDolphin) {


### PR DESCRIPTION
#105 

This adds additional settings to control toolbar opacity settings.

![settings](https://github.com/user-attachments/assets/61a08169-685f-4ba9-ba66-0870fedbd461)
![settings-2](https://github.com/user-attachments/assets/36b437d5-88a9-4b71-a9d8-5c64a99c0b3b)
