### PR TITLE
Plasma 6.3 changes for GH Actions

### DIFF
--- a/.github/assets/docker/kde-neon/Dockerfile
+++ b/.github/assets/docker/kde-neon/Dockerfile
@@ -8,6 +8,6 @@ RUN apt-get update && \
             kf6-kconfigwidgets-dev kf6-kcoreaddons-dev kf6-kguiaddons-dev kf6-ki18n-dev \
             kf6-kiconthemes-dev kf6-kirigami2-dev kf6-kpackage-dev kf6-kservice-dev \
             kf6-kwindowsystem-dev kirigami2-dev kwayland-dev libx11-dev \
-            libkdecorations2-dev libplasma-dev qt6-base-dev qt6-declarative-dev \
+            libkdecorations3-dev libplasma-dev qt6-base-dev qt6-declarative-dev \
             gettext qt6-svg-dev extra-cmake-modules qt3d5-dev && \
     userdel neon

--- a/.github/assets/specs/darkly.spec
+++ b/.github/assets/specs/darkly.spec
@@ -1,5 +1,5 @@
-%global kf6_version 6.2.0
-%define qt6_version 6.6.0
+%global kf6_version 6.3.0
+%define qt6_version 6.7.0
 %define kf5_version 5.102.0
 %define qt5_version 5.15.2
 %define dev Bali10050
@@ -96,10 +96,10 @@ Darkly is a fork of breeze theme style that aims to be visually modern and minim
 %{_datadir}/applications/kcm_%{_style}decoration.desktop
 %{_datadir}/kservices6/%{_style}decorationconfig.desktop
 %dir %{_kf6_qtplugindir}
-%dir %{_kf6_qtplugindir}/org.kde.kdecoration2.kcm
-%{_kf6_qtplugindir}/org.kde.kdecoration2.kcm/kcm_%{_style}decoration.so
-%dir %{_kf6_qtplugindir}/org.kde.kdecoration2/
-%{_kf6_qtplugindir}/org.kde.kdecoration2/org.kde.%{_style}.so
+%dir %{_kf6_qtplugindir}/org.kde.kdecoration3.kcm
+%{_kf6_qtplugindir}/org.kde.kdecoration3.kcm/kcm_%{_style}decoration.so
+%dir %{_kf6_qtplugindir}/org.kde.kdecoration3/
+%{_kf6_qtplugindir}/org.kde.kdecoration3/org.kde.%{_style}.so
 %dir %{_kf6_qtplugindir}/kstyle_config
 %{_kf6_qtplugindir}/kstyle_config/%{_style}styleconfig.so
 %dir %{_kf5_qtplugindir}/styles
@@ -127,10 +127,10 @@ Darkly is a fork of breeze theme style that aims to be visually modern and minim
 %{_kf6_applicationsdir}/kcm_%{_style}decoration.desktop
 %{_datadir}/kservices6/%{_style}decorationconfig.desktop
 %dir %{_kf6_plugindir}
-%dir %{_kf6_plugindir}/org.kde.kdecoration2.kcm
-%{_kf6_plugindir}/org.kde.kdecoration2.kcm/kcm_%{_style}decoration.so
-%dir %{_kf6_plugindir}/org.kde.kdecoration2/
-%{_kf6_plugindir}/org.kde.kdecoration2/org.kde.%{_style}.so
+%dir %{_kf6_plugindir}/org.kde.kdecoration3.kcm
+%{_kf6_plugindir}/org.kde.kdecoration3.kcm/kcm_%{_style}decoration.so
+%dir %{_kf6_plugindir}/org.kde.kdecoration3/
+%{_kf6_plugindir}/org.kde.kdecoration3/org.kde.%{_style}.so
 %dir %{_kf6_plugindir}/kstyle_config
 %{_kf6_plugindir}/kstyle_config/%{_style}styleconfig.so
 %dir %{_kf5_plugindir}/styles

--- a/.github/workflows/darkly-ci.yml
+++ b/.github/workflows/darkly-ci.yml
@@ -64,23 +64,23 @@ jobs:
       cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
       version: ${{ needs.release-ci.outputs.VERSION }}
 
-  # KDE-Neon:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/neon.yml
-  #   with:
-  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  KDE-Neon:
+    needs: release-ci
+    uses: ./.github/workflows/neon.yml
+    with:
+      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+      version: ${{ needs.release-ci.outputs.VERSION }}
 
-  # Fedora:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/fedora.yml
-  #   with:
-  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
-  #     containers: "['fedora:latest', 'fedora:40']"
+  Fedora:
+    needs: release-ci
+    uses: ./.github/workflows/fedora.yml
+    with:
+      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+      version: ${{ needs.release-ci.outputs.VERSION }}
+      containers: "['fedora:latest', 'fedora:40']"
 
-  # Archlinux:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/archlinux.yml
-  #   with:
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  Archlinux:
+    needs: release-ci
+    uses: ./.github/workflows/archlinux.yml
+    with:
+      version: ${{ needs.release-ci.outputs.VERSION }}

--- a/.github/workflows/darkly-ci.yml
+++ b/.github/workflows/darkly-ci.yml
@@ -57,12 +57,12 @@ jobs:
   #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
   #     version: ${{ needs.release-ci.outputs.VERSION }}
 
-  # openSUSE-Tumbleweed:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/opensuse-tw.yml
-  #   with:
-  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  openSUSE-Tumbleweed:
+    needs: release-ci
+    uses: ./.github/workflows/opensuse-tw.yml
+    with:
+      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+      version: ${{ needs.release-ci.outputs.VERSION }}
 
   KDE-Neon:
     needs: release-ci
@@ -71,16 +71,16 @@ jobs:
       cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
       version: ${{ needs.release-ci.outputs.VERSION }}
 
-  # Fedora:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/fedora.yml
-  #   with:
-  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
-  #     containers: "['fedora:latest', 'fedora:40']"
+  Fedora:
+    needs: release-ci
+    uses: ./.github/workflows/fedora.yml
+    with:
+      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+      version: ${{ needs.release-ci.outputs.VERSION }}
+      containers: "['fedora:latest', 'fedora:40']"
 
-  # Archlinux:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/archlinux.yml
-  #   with:
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  Archlinux:
+    needs: release-ci
+    uses: ./.github/workflows/archlinux.yml
+    with:
+      version: ${{ needs.release-ci.outputs.VERSION }}

--- a/.github/workflows/darkly-ci.yml
+++ b/.github/workflows/darkly-ci.yml
@@ -50,26 +50,26 @@ jobs:
           path: ${{ steps.step_get_asset.outputs.ASSET }}
           key: ${{ runner.os }}-v${{ steps.step_getlatest_tag.outputs.VERSION }}-${{ hashFiles(steps.step_get_asset.outputs.ASSET) }}
 
-  Kubuntu:
-    needs: release-ci
-    uses: ./.github/workflows/kubuntu.yml
-    with:
-      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-      version: ${{ needs.release-ci.outputs.VERSION }}
+  # Kubuntu:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/kubuntu.yml
+  #   with:
+  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+  #     version: ${{ needs.release-ci.outputs.VERSION }}
 
-  openSUSE-Tumbleweed:
-    needs: release-ci
-    uses: ./.github/workflows/opensuse-tw.yml
-    with:
-      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-      version: ${{ needs.release-ci.outputs.VERSION }}
+  # openSUSE-Tumbleweed:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/opensuse-tw.yml
+  #   with:
+  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+  #     version: ${{ needs.release-ci.outputs.VERSION }}
 
-  KDE-Neon:
-    needs: release-ci
-    uses: ./.github/workflows/neon.yml
-    with:
-      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-      version: ${{ needs.release-ci.outputs.VERSION }}
+  # KDE-Neon:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/neon.yml
+  #   with:
+  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+  #     version: ${{ needs.release-ci.outputs.VERSION }}
 
   Fedora:
     needs: release-ci
@@ -79,8 +79,8 @@ jobs:
       version: ${{ needs.release-ci.outputs.VERSION }}
       containers: "['fedora:latest', 'fedora:40']"
 
-  Archlinux:
-    needs: release-ci
-    uses: ./.github/workflows/archlinux.yml
-    with:
-      version: ${{ needs.release-ci.outputs.VERSION }}
+  # Archlinux:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/archlinux.yml
+  #   with:
+  #     version: ${{ needs.release-ci.outputs.VERSION }}

--- a/.github/workflows/darkly-ci.yml
+++ b/.github/workflows/darkly-ci.yml
@@ -57,12 +57,12 @@ jobs:
   #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
   #     version: ${{ needs.release-ci.outputs.VERSION }}
 
-  openSUSE-Tumbleweed:
-    needs: release-ci
-    uses: ./.github/workflows/opensuse-tw.yml
-    with:
-      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-      version: ${{ needs.release-ci.outputs.VERSION }}
+  # openSUSE-Tumbleweed:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/opensuse-tw.yml
+  #   with:
+  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+  #     version: ${{ needs.release-ci.outputs.VERSION }}
 
   KDE-Neon:
     needs: release-ci
@@ -71,16 +71,16 @@ jobs:
       cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
       version: ${{ needs.release-ci.outputs.VERSION }}
 
-  Fedora:
-    needs: release-ci
-    uses: ./.github/workflows/fedora.yml
-    with:
-      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-      version: ${{ needs.release-ci.outputs.VERSION }}
-      containers: "['fedora:latest', 'fedora:40']"
+  # Fedora:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/fedora.yml
+  #   with:
+  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  #     containers: "['fedora:latest', 'fedora:40']"
 
-  Archlinux:
-    needs: release-ci
-    uses: ./.github/workflows/archlinux.yml
-    with:
-      version: ${{ needs.release-ci.outputs.VERSION }}
+  # Archlinux:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/archlinux.yml
+  #   with:
+  #     version: ${{ needs.release-ci.outputs.VERSION }}

--- a/.github/workflows/darkly-ci.yml
+++ b/.github/workflows/darkly-ci.yml
@@ -57,12 +57,12 @@ jobs:
   #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
   #     version: ${{ needs.release-ci.outputs.VERSION }}
 
-  # openSUSE-Tumbleweed:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/opensuse-tw.yml
-  #   with:
-  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  openSUSE-Tumbleweed:
+    needs: release-ci
+    uses: ./.github/workflows/opensuse-tw.yml
+    with:
+      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+      version: ${{ needs.release-ci.outputs.VERSION }}
 
   # KDE-Neon:
   #   needs: release-ci
@@ -71,13 +71,13 @@ jobs:
   #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
   #     version: ${{ needs.release-ci.outputs.VERSION }}
 
-  Fedora:
-    needs: release-ci
-    uses: ./.github/workflows/fedora.yml
-    with:
-      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-      version: ${{ needs.release-ci.outputs.VERSION }}
-      containers: "['fedora:latest', 'fedora:40']"
+  # Fedora:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/fedora.yml
+  #   with:
+  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  #     containers: "['fedora:latest', 'fedora:40']"
 
   # Archlinux:
   #   needs: release-ci

--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -45,7 +45,7 @@ jobs:
         id: create_deb_package
         run: |
           cd build_kf6
-          cmake install .
+          make install .
           checkinstall -D --pkgname darkly --pkgversion ${{ inputs.version }} --nodoc --default
           deb_file=$(find . -name "*.deb*")
           test ! -z $deb_file && mv $deb_file /home/neon/darkly_${{ inputs.version }}_kdeneon_amd64.deb

--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    container: deltacopy/darkly-kde-neon:0.1
+    container: deltacopy/darkly-kde-neon:0.2
     steps:
       - uses: actions/cache/restore@v4
         id: cache

--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -33,7 +33,7 @@ jobs:
                     libkf5coreaddons-dev libkf5iconthemes-dev gettext qt3d5-dev libkf5kcmutils-dev \
                     qt6-base-dev libkf6coreaddons-dev \
                     libkf6config-dev libkf6guiaddons-dev libkf6i18n-dev libkf6iconthemes-dev \
-                    libkf6windowsystem-dev libkf6kcmutils-dev libkirigami-dev
+                    libkf6windowsystem-dev libkf6kcmutils-dev libkirigami-dev kf6-frameworkintegration-dev
       - name: Extract release tarball
         run: |
           tar xvf ${{ inputs.cache-file-path }}

--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -45,6 +45,7 @@ jobs:
         id: create_deb_package
         run: |
           cd build_kf6
+          cmake install .
           checkinstall -D --pkgname darkly --pkgversion ${{ inputs.version }} --nodoc --default
           deb_file=$(find . -name "*.deb*")
           test ! -z $deb_file && mv $deb_file /home/neon/darkly_${{ inputs.version }}_kdeneon_amd64.deb

--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -3,6 +3,10 @@
 # The Dockerfile is inside .github/assets/docker/kde-neon
 # Build Darkly from release tag and publish .deb package
 
+# Plasma 6.3 post installation notes.
+# Remove libkdecorations2private11
+# Remove libkdecorations2-6
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
I have disabled builds for Kubuntu which is still on Plasma 6.2
For KDE Neon 2 packages need to be removed post installation as it causes issues with loading the style properly.
Both of them are related to KDecoration2

- libkdecorations2private11
- libkdecorations2-6

Can also a new feature branch be created please ?

Something like feature-darkly6.3
