### PR TITLE
Shadow improvements

### DIFF
--- a/kdecoration/darklydecoration.cpp
+++ b/kdecoration/darklydecoration.cpp
@@ -758,7 +758,6 @@ void Decoration::createShadow()
         BoxShadowRenderer shadowRenderer;
         shadowRenderer.setBorderRadius(m_internalSettings->cornerRadius() + 0.5);
         shadowRenderer.setBoxSize(boxSize);
-        shadowRenderer.setDevicePixelRatio(1.0); // TODO: Create HiDPI shadows?
 
         const qreal strength = static_cast<qreal>(g_shadowStrength) / 255.0;
         shadowRenderer.addShadow(params.shadow1.offset, params.shadow1.radius, withOpacity(g_shadowColor, params.shadow1.opacity * strength));

--- a/kdecoration/darklydecoration.cpp
+++ b/kdecoration/darklydecoration.cpp
@@ -758,7 +758,7 @@ void Decoration::createShadow()
         BoxShadowRenderer shadowRenderer;
         shadowRenderer.setBorderRadius(m_internalSettings->cornerRadius() + 0.5);
         shadowRenderer.setBoxSize(boxSize);
-        // shadowRenderer.setDevicePixelRatio(1.0); // TODO: Create HiDPI shadows?
+        shadowRenderer.setDevicePixelRatio(1.0); // TODO: Create HiDPI shadows?
 
         const qreal strength = static_cast<qreal>(g_shadowStrength) / 255.0;
         shadowRenderer.addShadow(params.shadow1.offset, params.shadow1.radius, withOpacity(g_shadowColor, params.shadow1.opacity * strength));

--- a/kdecoration/darklydecoration.cpp
+++ b/kdecoration/darklydecoration.cpp
@@ -758,7 +758,7 @@ void Decoration::createShadow()
         BoxShadowRenderer shadowRenderer;
         shadowRenderer.setBorderRadius(m_internalSettings->cornerRadius() + 0.5);
         shadowRenderer.setBoxSize(boxSize);
-        shadowRenderer.setDevicePixelRatio(1.0); // TODO: Create HiDPI shadows?
+        // shadowRenderer.setDevicePixelRatio(1.0); // TODO: Create HiDPI shadows?
 
         const qreal strength = static_cast<qreal>(g_shadowStrength) / 255.0;
         shadowRenderer.addShadow(params.shadow1.offset, params.shadow1.radius, withOpacity(g_shadowColor, params.shadow1.opacity * strength));

--- a/kstyle/config/darklystyleconfig.cpp
+++ b/kstyle/config/darklystyleconfig.cpp
@@ -254,7 +254,7 @@ void StyleConfig::updateChanged()
     else if (_tabsHeight->value() != StyleConfigData::tabsHeight())
         modified = true;
 
-    if (_shadowSize->currentIndex() == 0 || _shadowIntensity->currentIndex() == 0) {
+    if (_shadowSize->currentIndex() == 0) {
         _shadowColor->setEnabled(false);
         _shadowIntensity->setEnabled(false);
         _shadowStrength->setEnabled(false);
@@ -313,7 +313,7 @@ void StyleConfig::load()
         }
     }
     _shadowSize->setCurrentIndex(StyleConfigData::shadowSize());
-    if (_shadowSize->currentIndex() == 0 || _shadowIntensity->currentIndex() == 0) {
+    if (_shadowSize->currentIndex() == 0) {
         _shadowColor->setEnabled(false);
         _shadowIntensity->setEnabled(false);
         _shadowStrength->setEnabled(false);

--- a/kstyle/config/darklystyleconfig.cpp
+++ b/kstyle/config/darklystyleconfig.cpp
@@ -254,7 +254,7 @@ void StyleConfig::updateChanged()
     else if (_tabsHeight->value() != StyleConfigData::tabsHeight())
         modified = true;
 
-    if (_shadowSize->currentIndex() == 0) {
+    if (_shadowSize->currentIndex() == 0 || _shadowIntensity->currentIndex() == 0) {
         _shadowColor->setEnabled(false);
         _shadowIntensity->setEnabled(false);
         _shadowStrength->setEnabled(false);
@@ -313,7 +313,7 @@ void StyleConfig::load()
         }
     }
     _shadowSize->setCurrentIndex(StyleConfigData::shadowSize());
-    if (_shadowSize->currentIndex() == 0) {
+    if (_shadowSize->currentIndex() == 0 || _shadowIntensity->currentIndex() == 0) {
         _shadowColor->setEnabled(false);
         _shadowIntensity->setEnabled(false);
         _shadowStrength->setEnabled(false);

--- a/kstyle/config/darklystyleconfig.cpp
+++ b/kstyle/config/darklystyleconfig.cpp
@@ -128,10 +128,6 @@ void StyleConfig::save()
     StyleConfigData::setButtonSize(_buttonSize->value());
     StyleConfigData::setKTextEditDrawFrame(_kTextEditDrawFrame->isChecked());
     StyleConfigData::setWidgetDrawShadow(_widgetDrawShadow->isChecked());
-
-    // switch (_shadowSize->currentIndex()) {
-    //     case 0: StyleConfigData::setShadowSize("ShadowNone");
-    // }
     StyleConfigData::setShadowSize(_shadowSize->currentIndex());
     StyleConfigData::setShadowColor(_shadowColor->color());
     StyleConfigData::setShadowStrength(_shadowStrength->value());

--- a/kstyle/config/darklystyleconfig.cpp
+++ b/kstyle/config/darklystyleconfig.cpp
@@ -81,7 +81,13 @@ StyleConfig::StyleConfig(QWidget *parent)
     connect(_toolBarOpacitySpinBox, SIGNAL(valueChanged(int)), _toolBarOpacity, SLOT(setValue(int)));
 
     connect(_kTextEditDrawFrame, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
+
     connect(_widgetDrawShadow, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
+    connect(_shadowSize, SIGNAL(currentIndexChanged(int)), SLOT(updateChanged()));
+    connect(_shadowColor, &KColorCombo::activated, this, &StyleConfig::updateChanged);
+    connect(_shadowStrength, SIGNAL(valueChanged(int)), _shadowStrength, SLOT(setValue(int)));
+    connect(_shadowIntensity, SIGNAL(currentIndexChanged(int)), SLOT(updateChanged()));
+
     connect(_scrollableMenu, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
     connect(_oldTabbar, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
     connect(_adjustToDarkThemes, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
@@ -122,6 +128,14 @@ void StyleConfig::save()
     StyleConfigData::setButtonSize(_buttonSize->value());
     StyleConfigData::setKTextEditDrawFrame(_kTextEditDrawFrame->isChecked());
     StyleConfigData::setWidgetDrawShadow(_widgetDrawShadow->isChecked());
+
+    // switch (_shadowSize->currentIndex()) {
+    //     case 0: StyleConfigData::setShadowSize("ShadowNone");
+    // }
+    StyleConfigData::setShadowSize(_shadowSize->currentIndex());
+    StyleConfigData::setShadowColor(_shadowColor->color());
+    StyleConfigData::setShadowStrength(_shadowStrength->value());
+    StyleConfigData::setShadowIntensity(_shadowIntensity->currentIndex());
     StyleConfigData::setScrollableMenu(_scrollableMenu->isChecked());
     StyleConfigData::setOldTabbar(_oldTabbar->isChecked());
     StyleConfigData::setAdjustToDarkThemes(_adjustToDarkThemes->isChecked());
@@ -215,6 +229,14 @@ void StyleConfig::updateChanged()
         modified = true;
     else if (_widgetDrawShadow->isChecked() != StyleConfigData::widgetDrawShadow())
         modified = true;
+    else if (_shadowSize->currentIndex() != StyleConfigData::shadowSize()) {
+        modified = true;
+    } else if (_shadowColor->color() != StyleConfigData::shadowColor())
+        modified = true;
+    else if (_shadowStrength->value() != StyleConfigData::shadowStrength())
+        modified = true;
+    else if (_shadowIntensity->currentIndex() != StyleConfigData::shadowIntensity())
+        modified = true;
     else if (_scrollableMenu->isChecked() != StyleConfigData::scrollableMenu())
         modified = true;
     else if (_oldTabbar->isChecked() != StyleConfigData::oldTabbar())
@@ -236,6 +258,15 @@ void StyleConfig::updateChanged()
     else if (_tabsHeight->value() != StyleConfigData::tabsHeight())
         modified = true;
 
+    if (_shadowSize->currentIndex() == 0) {
+        _shadowColor->setEnabled(false);
+        _shadowIntensity->setEnabled(false);
+        _shadowStrength->setEnabled(false);
+    } else {
+        _shadowColor->setEnabled(true);
+        _shadowIntensity->setEnabled(true);
+        _shadowStrength->setEnabled(true);
+    }
 
     emit changed(modified);
 }
@@ -272,6 +303,28 @@ void StyleConfig::load()
     _buttonSize->setValue(StyleConfigData::buttonSize());
     _kTextEditDrawFrame->setChecked(StyleConfigData::kTextEditDrawFrame());
     _widgetDrawShadow->setChecked(StyleConfigData::widgetDrawShadow());
+    for (QString &item : _shadowSizes) {
+        if (item == "None") {
+            _shadowSize->addItem(item, "ShadowNone");
+        } else if (item == "Small") {
+            _shadowSize->addItem(item, "ShadowSmall");
+        } else if (item == "Medium") {
+            _shadowSize->addItem(item, "ShadowMedium");
+        } else if (item == "Large") {
+            _shadowSize->addItem(item, "ShadowLarge");
+        } else if (item == "VeryLarge") {
+            _shadowSize->addItem(item, "ShadowVeryLarge");
+        }
+    }
+    _shadowSize->setCurrentIndex(StyleConfigData::shadowSize());
+    if (_shadowSize->currentIndex() == 0) {
+        _shadowColor->setEnabled(false);
+        _shadowIntensity->setEnabled(false);
+        _shadowStrength->setEnabled(false);
+    }
+    _shadowColor->setColor(StyleConfigData::shadowColor());
+    _shadowStrength->setValue(StyleConfigData::shadowStrength());
+    _shadowIntensity->setCurrentIndex(StyleConfigData::shadowIntensity());
     _scrollableMenu->setChecked(StyleConfigData::scrollableMenu());
     _oldTabbar->setChecked(StyleConfigData::oldTabbar());
     _adjustToDarkThemes->setChecked(StyleConfigData::adjustToDarkThemes());

--- a/kstyle/config/darklystyleconfig.h
+++ b/kstyle/config/darklystyleconfig.h
@@ -38,6 +38,9 @@ public:
     {
     }
 
+private:
+    std::list<QString> _shadowSizes = {"None", "Small", "Medium", "Large", "VeryLarge"};
+
 Q_SIGNALS:
 
     //* emitted whenever one option is changed.

--- a/kstyle/config/ui/darklystyleconfig.ui
+++ b/kstyle/config/ui/darklystyleconfig.ui
@@ -75,106 +75,6 @@
        <property name="spacing">
         <number>13</number>
        </property>
-       <item row="3" column="0" colspan="3">
-        <layout class="QGridLayout" name="gridLayout_4">
-         <property name="sizeConstraint">
-          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-         </property>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_2">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Button Size:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_16">
-           <property name="sizeConstraint">
-            <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_4">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Smaller</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Bigger</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSlider" name="_buttonSize">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimum">
-            <number>-2</number>
-           </property>
-           <property name="maximum">
-            <number>6</number>
-           </property>
-           <property name="singleStep">
-            <number>1</number>
-           </property>
-           <property name="sliderPosition">
-            <number>4</number>
-           </property>
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="tickPosition">
-            <enum>QSlider::TickPosition::TicksBelow</enum>
-           </property>
-           <property name="tickInterval">
-            <number>2</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
        <item row="2" column="0" colspan="3">
         <widget class="QCheckBox" name="_viewDrawFocusIndicator">
          <property name="text">
@@ -394,6 +294,106 @@
             </size>
            </property>
           </spacer>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0" rowspan="2" colspan="3">
+        <layout class="QGridLayout" name="gridLayout_4">
+         <property name="sizeConstraint">
+          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+         </property>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Button Size:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_16">
+           <property name="sizeConstraint">
+            <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Smaller</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Bigger</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSlider" name="_buttonSize">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimum">
+            <number>-2</number>
+           </property>
+           <property name="maximum">
+            <number>6</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="sliderPosition">
+            <number>4</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TickPosition::TicksBelow</enum>
+           </property>
+           <property name="tickInterval">
+            <number>2</number>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
@@ -1417,14 +1417,14 @@
               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
              <property name="indent">
-              <number>5</number>
+              <number>0</number>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QComboBox" name="_shadowSize">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -1435,7 +1435,7 @@
             </widget>
            </item>
            <item>
-            <spacer name="horizontalSpacer_10">
+            <spacer name="horizontalSpacer_5">
              <property name="orientation">
               <enum>Qt::Orientation::Horizontal</enum>
              </property>
@@ -1452,95 +1452,9 @@
          <item row="2" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_13">
            <item>
-            <widget class="QLabel" name="label_15">
-             <property name="text">
-              <string>Strength:</string>
-             </property>
-             <property name="indent">
-              <number>5</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="_shadowStrength">
-             <property name="minimum">
-              <number>25</number>
-             </property>
-             <property name="maximum">
-              <number>255</number>
-             </property>
-             <property name="value">
-              <number>255</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_6">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="1" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_14">
-           <item>
-            <widget class="QLabel" name="label_14">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Color:</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-             </property>
-             <property name="indent">
-              <number>5</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="KColorCombo" name="_shadowColor">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_8">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="3" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_20">
-           <item>
             <widget class="QLabel" name="label_17">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -1549,23 +1463,24 @@
               <string>Intensity:</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
              <property name="indent">
-              <number>5</number>
+              <number>0</number>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QComboBox" name="_shadowIntensity">
-             <property name="currentIndex">
-              <number>2</number>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
-             <item>
-              <property name="text">
-               <string>Off</string>
-              </property>
-             </item>
+             <property name="currentIndex">
+              <number>1</number>
+             </property>
              <item>
               <property name="text">
                <string>Low</string>
@@ -1589,7 +1504,108 @@
             </widget>
            </item>
            <item>
-            <spacer name="horizontalSpacer_5">
+            <spacer name="horizontalSpacer_10">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_14">
+           <item>
+            <widget class="QLabel" name="label_14">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Color:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+             <property name="indent">
+              <number>0</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="KColorCombo" name="_shadowColor">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_6">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="3" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_20">
+           <item>
+            <widget class="QLabel" name="label_15">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Strength:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+             <property name="indent">
+              <number>0</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="_shadowStrength">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimum">
+              <number>25</number>
+             </property>
+             <property name="maximum">
+              <number>255</number>
+             </property>
+             <property name="value">
+              <number>255</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_8">
              <property name="orientation">
               <enum>Qt::Orientation::Horizontal</enum>
              </property>

--- a/kstyle/config/ui/darklystyleconfig.ui
+++ b/kstyle/config/ui/darklystyleconfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>670</width>
-    <height>482</height>
+    <height>484</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1346,7 +1346,7 @@
       <widget class="QCheckBox" name="_widgetDrawShadow">
        <property name="geometry">
         <rect>
-         <x>10</x>
+         <x>20</x>
          <y>10</y>
          <width>339</width>
          <height>24</height>
@@ -1396,7 +1396,7 @@
           <x>10</x>
           <y>30</y>
           <width>591</width>
-          <height>178</height>
+          <height>198</height>
          </rect>
         </property>
         <layout class="QGridLayout" name="gridLayout_3">
@@ -1558,6 +1558,9 @@
            </item>
            <item>
             <widget class="QComboBox" name="_shadowIntensity">
+             <property name="currentIndex">
+              <number>2</number>
+             </property>
              <item>
               <property name="text">
                <string>Off</string>

--- a/kstyle/config/ui/darklystyleconfig.ui
+++ b/kstyle/config/ui/darklystyleconfig.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>650</width>
+    <width>670</width>
     <height>482</height>
    </rect>
   </property>
@@ -18,7 +18,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>650</width>
+    <width>660</width>
     <height>0</height>
    </size>
   </property>
@@ -1374,17 +1374,20 @@
        <widget class="QLabel" name="label_16">
         <property name="geometry">
          <rect>
-          <x>150</x>
+          <x>50</x>
           <y>4</y>
-          <width>401</width>
-          <height>16</height>
+          <width>541</width>
+          <height>20</height>
          </rect>
         </property>
         <property name="frameShape">
          <enum>QFrame::Shape::NoFrame</enum>
         </property>
         <property name="text">
-         <string>These settings change how the menu shadow outlines are displayed</string>
+         <string>These settings change how menu shadow outlines are displayed</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
        </widget>
        <widget class="QWidget" name="gridLayoutWidget">
@@ -1427,7 +1430,7 @@
               </sizepolicy>
              </property>
              <property name="currentIndex">
-              <number>3</number>
+              <number>-1</number>
              </property>
             </widget>
            </item>

--- a/kstyle/config/ui/darklystyleconfig.ui
+++ b/kstyle/config/ui/darklystyleconfig.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>772</width>
-    <height>545</height>
+    <width>650</width>
+    <height>482</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -15,6 +15,12 @@
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>650</width>
+    <height>0</height>
+   </size>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="leftMargin">
@@ -69,241 +75,325 @@
        <property name="spacing">
         <number>13</number>
        </property>
-       <item row="0" column="1">
-        <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item row="3" column="0" colspan="3">
+        <layout class="QGridLayout" name="gridLayout_4">
          <property name="sizeConstraint">
-          <enum>QLayout::SizeConstraint::SetMaximumSize</enum>
+          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
          </property>
-         <item>
-          <widget class="QCheckBox" name="_toolBarDrawItemSeparator">
-           <property name="text">
-            <string>Draw toolbar item separators</string>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="_viewDrawFocusIndicator">
            <property name="text">
-            <string>Draw focus indicator in lists</string>
+            <string>Button Size:</string>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="_widgetDrawShadow">
-           <property name="text">
-            <string>Draw widget shadow</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="_scrollableMenu">
-           <property name="text">
-            <string>Scrollable popup menu</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QFormLayout" name="formLayout_4">
-           <property name="labelAlignment">
+           <property name="alignment">
             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
-           <item row="0" column="0">
-            <widget class="QLabel" name="_cornerRadiusLabel">
-             <property name="text">
-              <string>Corner radius:</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
-             </property>
-             <property name="indent">
-              <number>5</number>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QSpinBox" name="_cornerRadius">
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_16">
+           <property name="sizeConstraint">
+            <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_4">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="suffix">
-              <string> px</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>8</number>
-             </property>
-             <property name="value">
-              <number>6</number>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="_mnemonicsLabel">
-             <property name="text">
-              <string>Keyboard accelerators visibility:</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
-             </property>
-             <property name="indent">
-              <number>5</number>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QComboBox" name="_mnemonicsMode">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <item>
-              <property name="text">
-               <string>Always Hide</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>When Needed</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Always Show</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="_windowDragLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Windows' &amp;drag mode:</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
-             </property>
-             <property name="indent">
-              <number>5</number>
-             </property>
-             <property name="buddy">
-              <cstring>_windowDragMode</cstring>
+              <string>Smaller</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
-            <widget class="QComboBox" name="_windowDragMode">
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_3">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <item>
-              <property name="text">
-               <string>Drag windows from titlebar only</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Drag windows from titlebar, menubar and toolbars</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Drag windows from all empty areas</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_2">
-             <property name="layoutDirection">
-              <enum>Qt::LayoutDirection::LeftToRight</enum>
-             </property>
              <property name="text">
-              <string>Button Size:</string>
-             </property>
-             <property name="indent">
-              <number>5</number>
+              <string>Bigger</string>
              </property>
             </widget>
-           </item>
-           <item row="3" column="1">
-            <layout class="QFormLayout" name="formLayout_2">
-             <item row="0" column="0" colspan="2">
-              <widget class="QSlider" name="_buttonSize">
-               <property name="minimum">
-                <number>-2</number>
-               </property>
-               <property name="maximum">
-                <number>6</number>
-               </property>
-               <property name="singleStep">
-                <number>1</number>
-               </property>
-               <property name="sliderPosition">
-                <number>4</number>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="tickPosition">
-                <enum>QSlider::TickPosition::TicksBelow</enum>
-               </property>
-               <property name="tickInterval">
-                <number>2</number>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0" colspan="2">
-              <layout class="QHBoxLayout" name="horizontalLayout_4">
-               <item>
-                <widget class="QLabel" name="label_3">
-                 <property name="text">
-                  <string>Smaller</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_4">
-                 <property name="text">
-                  <string>Bigger</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
            </item>
           </layout>
          </item>
-         <item>
-          <widget class="QLabel" name="_versionNumber">
-           <property name="layoutDirection">
-            <enum>Qt::LayoutDirection::RightToLeft</enum>
+         <item row="1" column="1">
+          <widget class="QSlider" name="_buttonSize">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-           <property name="text">
-            <string>VERSION</string>
+           <property name="minimum">
+            <number>-2</number>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing</set>
+           <property name="maximum">
+            <number>6</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="sliderPosition">
+            <number>4</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TickPosition::TicksBelow</enum>
+           </property>
+           <property name="tickInterval">
+            <number>2</number>
            </property>
           </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="2" column="0" colspan="3">
+        <widget class="QCheckBox" name="_viewDrawFocusIndicator">
+         <property name="text">
+          <string>Draw focus indicator in lists</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="3">
+        <widget class="QCheckBox" name="_toolBarDrawItemSeparator">
+         <property name="text">
+          <string>Draw toolbar item separators</string>
+         </property>
+        </widget>
+       </item>
+       <item row="54" column="2">
+        <widget class="QLabel" name="_versionNumber">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="layoutDirection">
+          <enum>Qt::LayoutDirection::RightToLeft</enum>
+         </property>
+         <property name="text">
+          <string>VERSION</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="3">
+        <widget class="QCheckBox" name="_scrollableMenu">
+         <property name="text">
+          <string>Scrollable popup menu</string>
+         </property>
+        </widget>
+       </item>
+       <item row="51" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
+         <item>
+          <widget class="QLabel" name="label_12">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Corner Radius:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="_cornerRadius">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>8</number>
+           </property>
+           <property name="value">
+            <number>6</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_9">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item row="52" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_18">
+         <item>
+          <widget class="QLabel" name="_mnemonicsLabel">
+           <property name="text">
+            <string>Keyboard accelerators visibility:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="_mnemonicsMode">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LayoutDirection::LeftToRight</enum>
+           </property>
+           <item>
+            <property name="text">
+             <string>Always Hide</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>When Needed</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Always Show</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_12">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item row="53" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_19">
+         <item>
+          <widget class="QLabel" name="_windowDragLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Windows' &amp;drag mode:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+           <property name="buddy">
+            <cstring>_windowDragMode</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="_windowDragMode">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QComboBox::SizeAdjustPolicy::AdjustToContentsOnFirstShow</enum>
+           </property>
+           <item>
+            <property name="text">
+             <string>Titlebar only</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Titlebar, menubar and toolbars</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>All empty areas</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_7">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
@@ -558,47 +648,73 @@
            </property>
           </widget>
          </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_15">
          <item>
-          <layout class="QFormLayout" name="formLayout_3">
-           <item row="0" column="0">
-            <widget class="QLabel" name="_animationsDurationLabel">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string>A&amp;nimations duration:</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing</set>
-             </property>
-             <property name="indent">
-              <number>5</number>
-             </property>
-             <property name="buddy">
-              <cstring>_animationsDuration</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QSpinBox" name="_animationsDuration">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="suffix">
-              <string> ms</string>
-             </property>
-             <property name="maximum">
-              <number>500</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          <widget class="QLabel" name="_animationsDurationLabel">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>A&amp;nimations duration:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+           <property name="buddy">
+            <cstring>_animationsDuration</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="_animationsDuration">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="suffix">
+            <string> ms</string>
+           </property>
+           <property name="maximum">
+            <number>500</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
@@ -699,109 +815,169 @@
       <attribute name="title">
        <string>Scrollbars</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_6">
+      <layout class="QGridLayout" name="gridLayout_6" rowstretch="0,0,0,0" columnstretch="0">
        <property name="leftMargin">
         <number>13</number>
        </property>
+       <property name="rightMargin">
+        <number>13</number>
+       </property>
+       <property name="bottomMargin">
+        <number>13</number>
+       </property>
+       <property name="spacing">
+        <number>13</number>
+       </property>
        <item row="0" column="0">
-        <layout class="QVBoxLayout" name="verticalLayout_7">
-         <property name="leftMargin">
-          <number>2</number>
+        <widget class="QCheckBox" name="_renderThinSeperatorBetweenTheScrollBar">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
+         <property name="text">
+          <string>Render a thin separator between the scrollbar</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_12">
          <item>
-          <widget class="QCheckBox" name="_renderThinSeperatorBetweenTheScrollBar">
+          <widget class="QLabel" name="_scrollBarAddLineLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
-            <string>Render a thin separator between the scrollbar</string>
+            <string>Bottom arrow button t&amp;ype:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+           <property name="buddy">
+            <cstring>_scrollBarAddLineButtons</cstring>
            </property>
           </widget>
          </item>
          <item>
-          <layout class="QFormLayout" name="formLayout">
-           <item row="1" column="1">
-            <widget class="QComboBox" name="_scrollBarAddLineButtons">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <item>
-              <property name="text">
-               <string>No Buttons</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>One Button</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Two Buttons</string>
-              </property>
-             </item>
-            </widget>
+          <widget class="QComboBox" name="_scrollBarAddLineButtons">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <item>
+            <property name="text">
+             <string>No Buttons</string>
+            </property>
            </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="_scrollBarAddLineLabel">
-             <property name="text">
-              <string>Bottom arrow button t&amp;ype:</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
-             </property>
-             <property name="indent">
-              <number>5</number>
-             </property>
-             <property name="buddy">
-              <cstring>_scrollBarAddLineButtons</cstring>
-             </property>
-            </widget>
+           <item>
+            <property name="text">
+             <string>One Button</string>
+            </property>
            </item>
-           <item row="0" column="1">
-            <widget class="QComboBox" name="_scrollBarSubLineButtons">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <item>
-              <property name="text">
-               <string>No Buttons</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>One Button</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Two Buttons</string>
-              </property>
-             </item>
-            </widget>
+           <item>
+            <property name="text">
+             <string>Two Buttons</string>
+            </property>
            </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="_scrollBarSubLineLabel">
-             <property name="text">
-              <string>&amp;Top arrow button type:       </string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
-             </property>
-             <property name="indent">
-              <number>5</number>
-             </property>
-             <property name="buddy">
-              <cstring>_scrollBarSubLineButtons</cstring>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
+       </item>
+       <item row="1" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="QLabel" name="_scrollBarSubLineLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&amp;Top arrow button type:       </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="buddy">
+            <cstring>_scrollBarSubLineButtons</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="_scrollBarSubLineButtons">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <item>
+            <property name="text">
+             <string>No Buttons</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>One Button</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Two Buttons</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -1163,6 +1339,268 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="Shadow">
+      <attribute name="title">
+       <string>Shadow</string>
+      </attribute>
+      <widget class="QCheckBox" name="_widgetDrawShadow">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>339</width>
+         <height>24</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Draw widget shadow</string>
+       </property>
+      </widget>
+      <widget class="QFrame" name="frame">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>40</y>
+         <width>611</width>
+         <height>231</height>
+        </rect>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::Shape::NoFrame</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Shadow::Plain</enum>
+       </property>
+       <widget class="QLabel" name="label_16">
+        <property name="geometry">
+         <rect>
+          <x>150</x>
+          <y>4</y>
+          <width>401</width>
+          <height>16</height>
+         </rect>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
+        </property>
+        <property name="text">
+         <string>These settings change how the menu shadow outlines are displayed</string>
+        </property>
+       </widget>
+       <widget class="QWidget" name="gridLayoutWidget">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>30</y>
+          <width>591</width>
+          <height>178</height>
+         </rect>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="0" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_21">
+           <item>
+            <widget class="QLabel" name="label_13">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Size:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+             </property>
+             <property name="indent">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="_shadowSize">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="currentIndex">
+              <number>3</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_10">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="2" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_13">
+           <item>
+            <widget class="QLabel" name="label_15">
+             <property name="text">
+              <string>Strength:</string>
+             </property>
+             <property name="indent">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="_shadowStrength">
+             <property name="minimum">
+              <number>25</number>
+             </property>
+             <property name="maximum">
+              <number>255</number>
+             </property>
+             <property name="value">
+              <number>255</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_6">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_14">
+           <item>
+            <widget class="QLabel" name="label_14">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Color:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+             </property>
+             <property name="indent">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="KColorCombo" name="_shadowColor">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_8">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="3" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_20">
+           <item>
+            <widget class="QLabel" name="label_17">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Intensity:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+             </property>
+             <property name="indent">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="_shadowIntensity">
+             <item>
+              <property name="text">
+               <string>Off</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Low</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Medium</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>High</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Maximum</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_5">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </widget>
     </widget>
    </item>
   </layout>
@@ -1172,6 +1610,11 @@
    <class>KColorButton</class>
    <extends>QPushButton</extends>
    <header>kcolorbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>KColorCombo</class>
+   <extends>QComboBox</extends>
+   <header>kcolorcombo.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/kstyle/darkly.kcfg
+++ b/kstyle/darkly.kcfg
@@ -35,7 +35,6 @@
     <!-- shadow intensity -->
      <entry name="ShadowIntensity" type = "Enum">
        <choices>
-          <choice name="Off"/>
           <choice name="Low"/>
           <choice name="Medium"/>
           <choice name="High"/>

--- a/kstyle/darkly.kcfg
+++ b/kstyle/darkly.kcfg
@@ -8,14 +8,14 @@
   <!-- common options -->
   <group name="Common">
 
-    <!-- shadow -->
+    <!-- shadow strength-->
     <entry name="ShadowStrength" type = "Int">
-       <default>102</default>
+       <default>255</default>
        <min>25</min>
        <max>255</max>
     </entry>
 
-    <!-- shadow -->
+    <!-- shadow size -->
     <entry name="ShadowSize" type = "Enum">
       <choices>
           <choice name="ShadowNone"/>
@@ -27,8 +27,21 @@
       <default>ShadowLarge</default>
     </entry>
 
+    <!-- shadow color -->
     <entry name="ShadowColor" type = "Color">
        <default>0, 0, 0</default>
+    </entry>
+
+    <!-- shadow intensity -->
+     <entry name="ShadowIntensity" type = "Enum">
+       <choices>
+          <choice name="Off"/>
+          <choice name="Low"/>
+          <choice name="Medium"/>
+          <choice name="High"/>
+          <choice name="Maximum"/>
+      </choices>
+      <default>Medium</default>
     </entry>
 
     <!-- close button -->
@@ -42,6 +55,8 @@
        <min>1</min>
        <max>8</max>
     </entry>
+
+    <!-- button size -->
     <entry name="ButtonSize" type="Int">
         <default>4</default>
     </entry>

--- a/kstyle/darklyhelper.cpp
+++ b/kstyle/darklyhelper.cpp
@@ -20,6 +20,7 @@
 #include "darklyhelper.h"
 
 #include "darkly.h"
+#include "darklypropertynames.h"
 
 #include <KColorUtils>
 #include <KIconLoader>

--- a/kstyle/darklymdiwindowshadow.cpp
+++ b/kstyle/darklymdiwindowshadow.cpp
@@ -53,21 +53,21 @@ void MdiWindowShadow::updateGeometry()
     if (params.isNone())
         return;
 
-    const QSize boxSize =
+    const QSizeF boxSize =
         BoxShadowRenderer::calculateMinimumBoxSize(params.shadow1.radius).expandedTo(BoxShadowRenderer::calculateMinimumBoxSize(params.shadow2.radius));
 
-    const QSize shadowSize = BoxShadowRenderer::calculateMinimumShadowTextureSize(boxSize, params.shadow1.radius, params.shadow1.offset)
-                                 .expandedTo(BoxShadowRenderer::calculateMinimumShadowTextureSize(boxSize, params.shadow2.radius, params.shadow2.offset));
+    const QSizeF shadowSize = BoxShadowRenderer::calculateMinimumShadowTextureSize(boxSize, params.shadow1.radius, params.shadow1.offset)
+                                  .expandedTo(BoxShadowRenderer::calculateMinimumShadowTextureSize(boxSize, params.shadow2.radius, params.shadow2.offset));
 
-    const QRect shadowRect(QPoint(0, 0), shadowSize);
+    const QRectF shadowRect(QPoint(0, 0), shadowSize);
 
-    QRect boxRect(QPoint(0, 0), boxSize);
+    QRectF boxRect(QPoint(0, 0), boxSize);
     boxRect.moveCenter(shadowRect.center());
 
-    const int topSize(boxRect.top() - shadowRect.top() - Metrics::Shadow_Overlap - params.offset.y());
-    const int bottomSize(shadowRect.bottom() - boxRect.bottom() - Metrics::Shadow_Overlap + params.offset.y());
-    const int leftSize(boxRect.left() - shadowRect.left() - Metrics::Shadow_Overlap - params.offset.x());
-    const int rightSize(shadowRect.right() - boxRect.right() - Metrics::Shadow_Overlap + params.offset.x());
+    const double topSize(boxRect.top() - shadowRect.top() - int(Metrics::Shadow_Overlap) - params.offset.y());
+    const double bottomSize(shadowRect.bottom() - boxRect.bottom() - int(Metrics::Shadow_Overlap) + params.offset.y());
+    const double leftSize(boxRect.left() - shadowRect.left() - int(Metrics::Shadow_Overlap) - params.offset.x());
+    const double rightSize(shadowRect.right() - boxRect.right() - int(Metrics::Shadow_Overlap) + params.offset.x());
 
     // get tileSet rect
     auto hole = _widget->frameGeometry();
@@ -244,7 +244,7 @@ void MdiWindowShadowFactory::installShadow(QObject *object)
         return;
 
     // create new shadow
-    auto windowShadow(new MdiWindowShadow(widget->parentWidget(), _shadowHelper->shadowTiles()));
+    auto windowShadow(new MdiWindowShadow(widget->parentWidget(), _shadowHelper->shadowTiles(widget)));
     windowShadow->setWidget(widget);
 }
 

--- a/kstyle/darklyshadowhelper.cpp
+++ b/kstyle/darklyshadowhelper.cpp
@@ -45,13 +45,26 @@ const CompositeShadowParams s_shadowParams[] = {
     // None
     CompositeShadowParams(),
     // Small
-    CompositeShadowParams(QPoint(0, 8), ShadowParams(QPoint(0, 0), 8, 0.8), ShadowParams(QPoint(0, -4), 4, 0.16), ShadowParams(QPoint(0, -6), 2, 0.12)),
+    CompositeShadowParams(QPoint(0, 3), ShadowParams(QPoint(0, 0), 12, 0.26), ShadowParams(QPoint(0, -2), 6, 0.16)),
     // Medium
-    CompositeShadowParams(QPoint(0, 8), ShadowParams(QPoint(0, 0), 20, 0.24), ShadowParams(QPoint(0, -4), 8, 0.32), ShadowParams(QPoint(0, -6), 4, 0.01)),
+    CompositeShadowParams(QPoint(0, 4), ShadowParams(QPoint(0, 0), 16, 0.24), ShadowParams(QPoint(0, -2), 8, 0.14)),
     // Large
-    CompositeShadowParams(QPoint(0, 16), ShadowParams(QPoint(0, 0), 28, 0.20), ShadowParams(QPoint(0, -8), 16, 0.24), ShadowParams(QPoint(0, -13), 6, 0.16)),
+    CompositeShadowParams(QPoint(0, 5), ShadowParams(QPoint(0, 0), 20, 0.22), ShadowParams(QPoint(0, -3), 10, 0.12)),
     // Very Large
-    CompositeShadowParams(QPoint(0, 32), ShadowParams(QPoint(0, 0), 40, 0.12), ShadowParams(QPoint(0, -16), 20, 0.20), ShadowParams(QPoint(0, -27), 5, 0.24))};
+    CompositeShadowParams(QPoint(0, 6), ShadowParams(QPoint(0, 0), 24, 0.2), ShadowParams(QPoint(0, -3), 12, 0.1))};
+
+/*
+old values
+
+CompositeShadowParams(QPoint(0, 8), ShadowParams(QPoint(0, 0), 8, 0.8), ShadowParams(QPoint(0, -4), 4, 0.16), ShadowParams(QPoint(0, -6), 2, 0.12)),
+// Medium
+CompositeShadowParams(QPoint(0, 8), ShadowParams(QPoint(0, 0), 20, 0.24), ShadowParams(QPoint(0, -4), 8, 0.32), ShadowParams(QPoint(0, -6), 4, 0.01)),
+// Large
+CompositeShadowParams(QPoint(0, 16), ShadowParams(QPoint(0, 0), 28, 0.20), ShadowParams(QPoint(0, -8), 16, 0.24), ShadowParams(QPoint(0, -13), 6, 0.16)),
+// Very Large
+CompositeShadowParams(QPoint(0, 32), ShadowParams(QPoint(0, 0), 40, 0.12), ShadowParams(QPoint(0, -16), 20, 0.20), ShadowParams(QPoint(0, -27), 5, 0.24))};
+
+*/
 }
 
 namespace Darkly
@@ -74,6 +87,26 @@ CompositeShadowParams ShadowHelper::lookupShadowParams(int shadowSizeEnum)
     default:
         // Fallback to the Large size.
         return s_shadowParams[3];
+    }
+}
+
+//_____________________________________________________
+int ShadowHelper::lookupIntensityParams(int shadowIntensityEnum)
+{
+    switch (shadowIntensityEnum) {
+    case StyleConfigData::Off:
+        return 0;
+    case StyleConfigData::Low:
+        return 1;
+    case StyleConfigData::Medium:
+        return 2;
+    case StyleConfigData::High:
+        return 3;
+    case StyleConfigData::Maximum:
+        return 4;
+    default:
+        // Fallback to the High size.
+        return 3;
     }
 }
 
@@ -185,15 +218,18 @@ bool ShadowHelper::eventFilter(QObject *object, QEvent *event)
 }
 
 //_______________________________________________________
-TileSet ShadowHelper::shadowTiles()
+TileSet ShadowHelper::shadowTiles(QWidget *widget)
 {
-    const CompositeShadowParams params = lookupShadowParams(StyleConfigData::shadowSize());
+    CompositeShadowParams params = lookupShadowParams(StyleConfigData::shadowSize());
 
     if (params.isNone()) {
         return TileSet();
     } else if (_shadowTiles.isValid()) {
         return _shadowTiles;
     }
+
+    const qreal dpr = Helper::isWayland() ? 1 : widget->devicePixelRatioF();
+    params *= dpr;
 
     auto withOpacity = [](const QColor &color, qreal opacity) -> QColor {
         QColor c(color);
@@ -202,27 +238,26 @@ TileSet ShadowHelper::shadowTiles()
     };
 
     const QColor color = StyleConfigData::shadowColor();
-    const qreal strength = static_cast<qreal>(StyleConfigData::shadowStrength()) / 255.0;
 
-    const QSize boxSize = BoxShadowRenderer::calculateMinimumBoxSize(params.shadow1.radius)
-                              .expandedTo(BoxShadowRenderer::calculateMinimumBoxSize(params.shadow2.radius))
-                              .expandedTo(BoxShadowRenderer::calculateMinimumBoxSize(params.shadow3.radius));
+    // shadowIntensity {Off, Low, Medium, High, Maximum}
+    const qreal intensityParams = lookupIntensityParams(StyleConfigData::shadowIntensity());
+    const qreal strength = static_cast<qreal>(StyleConfigData::shadowStrength() * intensityParams) / 255.0;
 
-    const qreal dpr = qApp->devicePixelRatio();
-    const qreal frameRadius = _helper.frameRadius(1);
+    const QSize boxSize =
+        BoxShadowRenderer::calculateMinimumBoxSize(params.shadow1.radius).expandedTo(BoxShadowRenderer::calculateMinimumBoxSize(params.shadow2.radius));
+
+    const qreal frameRadius = _helper.frameRadius();
 
     BoxShadowRenderer shadowRenderer;
     shadowRenderer.setBorderRadius(frameRadius);
     shadowRenderer.setBoxSize(boxSize);
-    shadowRenderer.setDevicePixelRatio(dpr);
 
     shadowRenderer.addShadow(params.shadow1.offset, params.shadow1.radius, withOpacity(color, params.shadow1.opacity * strength));
     shadowRenderer.addShadow(params.shadow2.offset, params.shadow2.radius, withOpacity(color, params.shadow2.opacity * strength));
-    shadowRenderer.addShadow(params.shadow3.offset, params.shadow3.radius, withOpacity(color, params.shadow3.opacity * strength));
 
     QImage shadowTexture = shadowRenderer.render();
 
-    const QRect outerRect(QPoint(0, 0), shadowTexture.size() / dpr);
+    const QRect outerRect(QPoint(0, 0), shadowTexture.size());
 
     QRect boxRect(QPoint(0, 0), boxSize);
     boxRect.moveCenter(outerRect.center());
@@ -241,7 +276,7 @@ TileSet ShadowHelper::shadowTiles()
     painter.setCompositionMode(QPainter::CompositionMode_DestinationOut);
     painter.drawRoundedRect(outerRect - margins, frameRadius, frameRadius);
 
-    // Draw outline.
+    // // Draw outline.
     painter.setPen(withOpacity(Qt::black, 0.1 * strength));
     painter.setBrush(Qt::NoBrush);
     painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
@@ -274,12 +309,9 @@ TileSet ShadowHelper::shadowTiles(const int frameRadius, CustomShadowParams shad
 
     const QSize boxSize = BoxShadowRenderer::calculateMinimumBoxSize(shadow1.radius).expandedTo(BoxShadowRenderer::calculateMinimumBoxSize(shadow2.radius));
 
-    const qreal dpr = qApp->devicePixelRatio();
-
     BoxShadowRenderer shadowRenderer;
     shadowRenderer.setBorderRadius(frameRadius);
     shadowRenderer.setBoxSize(boxSize);
-    shadowRenderer.setDevicePixelRatio(dpr);
 
     shadowRenderer.addShadow(shadow1.offset, shadow1.radius, shadow1.color);
     if (shadow2.radius > 0)
@@ -287,7 +319,7 @@ TileSet ShadowHelper::shadowTiles(const int frameRadius, CustomShadowParams shad
 
     QImage shadowTexture = shadowRenderer.render();
 
-    const QRect outerRect(QPoint(0, 0), shadowTexture.size() / dpr);
+    const QRect outerRect(QPoint(0, 0), shadowTexture.size());
 
     QRect boxRect(QPoint(0, 0), boxSize);
     boxRect.moveCenter(outerRect.center());
@@ -437,7 +469,7 @@ void ShadowHelper::installShadows(QWidget *widget)
         return;
 
     // create shadow tiles if needed
-    shadowTiles();
+    shadowTiles(widget);
     if (!_shadowTiles.isValid())
         return;
 
@@ -480,26 +512,29 @@ void ShadowHelper::installShadows(QWidget *widget)
 //_______________________________________________________
 QMargins ShadowHelper::shadowMargins(QWidget *widget) const
 {
-    const CompositeShadowParams params = lookupShadowParams(StyleConfigData::shadowSize());
+    CompositeShadowParams params = lookupShadowParams(StyleConfigData::shadowSize());
     if (params.isNone()) {
         return QMargins();
     }
 
+    qreal dpr = Helper::isWayland() ? 1 : widget->devicePixelRatioF();
+    params *= dpr;
+
     const QSize boxSize =
         BoxShadowRenderer::calculateMinimumBoxSize(params.shadow1.radius).expandedTo(BoxShadowRenderer::calculateMinimumBoxSize(params.shadow2.radius));
 
-    const QSize shadowSize = BoxShadowRenderer::calculateMinimumShadowTextureSize(boxSize, params.shadow1.radius, params.shadow1.offset)
-                                 .expandedTo(BoxShadowRenderer::calculateMinimumShadowTextureSize(boxSize, params.shadow2.radius, params.shadow2.offset));
+    const QSizeF shadowSize = BoxShadowRenderer::calculateMinimumShadowTextureSize(boxSize, params.shadow1.radius, params.shadow1.offset)
+                                  .expandedTo(BoxShadowRenderer::calculateMinimumShadowTextureSize(boxSize, params.shadow2.radius, params.shadow2.offset));
 
-    const QRect shadowRect(QPoint(0, 0), shadowSize);
+    const QRectF shadowRect(QPoint(0, 0), shadowSize);
 
-    QRect boxRect(QPoint(0, 0), boxSize);
+    QRectF boxRect(QPoint(0, 0), boxSize);
     boxRect.moveCenter(shadowRect.center());
 
-    QMargins margins(boxRect.left() - shadowRect.left() - Metrics::Shadow_Overlap - params.offset.x(),
-                     boxRect.top() - shadowRect.top() - Metrics::Shadow_Overlap - params.offset.y(),
-                     shadowRect.right() - boxRect.right() - Metrics::Shadow_Overlap + params.offset.x(),
-                     shadowRect.bottom() - boxRect.bottom() - Metrics::Shadow_Overlap + params.offset.y());
+    QMarginsF margins(boxRect.left() - shadowRect.left() - int(Metrics::Shadow_Overlap) - params.offset.x(),
+                      boxRect.top() - shadowRect.top() - int(Metrics::Shadow_Overlap) - params.offset.y(),
+                      shadowRect.right() - boxRect.right() - int(Metrics::Shadow_Overlap) + params.offset.x(),
+                      shadowRect.bottom() - boxRect.bottom() - int(Metrics::Shadow_Overlap) + params.offset.y());
 
     if (widget->inherits("QBalloonTip")) {
         // Balloon tip needs special margins to deal with the arrow.
@@ -518,9 +553,9 @@ QMargins ShadowHelper::shadowMargins(QWidget *widget) const
         }
     }
 
-    margins *= _helper.devicePixelRatio(_shadowTiles.pixmap(0));
+    // margins *= _helper.devicePixelRatio(_shadowTiles.pixmap(0));
 
-    return margins;
+    return margins.toMargins();
 }
 
 //_______________________________________________________

--- a/kstyle/darklyshadowhelper.cpp
+++ b/kstyle/darklyshadowhelper.cpp
@@ -94,8 +94,6 @@ CompositeShadowParams ShadowHelper::lookupShadowParams(int shadowSizeEnum)
 int ShadowHelper::lookupIntensityParams(int shadowIntensityEnum)
 {
     switch (shadowIntensityEnum) {
-    case StyleConfigData::Off:
-        return 0;
     case StyleConfigData::Low:
         return 1;
     case StyleConfigData::Medium:
@@ -239,7 +237,7 @@ TileSet ShadowHelper::shadowTiles(QWidget *widget)
 
     const QColor color = StyleConfigData::shadowColor();
 
-    // shadowIntensity {Off, Low, Medium, High, Maximum}
+    // shadowIntensity {Low, Medium, High, Maximum}
     const qreal intensityParams = lookupIntensityParams(StyleConfigData::shadowIntensity());
     const qreal strength = static_cast<qreal>(StyleConfigData::shadowStrength() * intensityParams) / 255.0;
 

--- a/kstyle/darklyshadowhelper.h
+++ b/kstyle/darklyshadowhelper.h
@@ -50,6 +50,12 @@ struct ShadowParams {
     QPoint offset;
     int radius = 0;
     qreal opacity = 0;
+
+    void operator*=(qreal factor)
+    {
+        offset *= factor;
+        radius = qRound(radius * factor);
+    }
 };
 
 struct CustomShadowParams {
@@ -70,23 +76,28 @@ struct CustomShadowParams {
 struct CompositeShadowParams {
     CompositeShadowParams() = default;
 
-    CompositeShadowParams(const QPoint &offset, const ShadowParams &shadow1, const ShadowParams &shadow2, const ShadowParams &shadow3)
+    CompositeShadowParams(const QPoint &offset, const ShadowParams &shadow1, const ShadowParams &shadow2)
         : offset(offset)
         , shadow1(shadow1)
         , shadow2(shadow2)
-        , shadow3(shadow3)
     {
     }
 
     bool isNone() const
     {
-        return qMax(shadow1.radius, qMax(shadow2.radius, shadow3.radius)) == 0;
+        return qMax(shadow1.radius, shadow2.radius) == 0;
     }
 
     QPoint offset;
     ShadowParams shadow1;
     ShadowParams shadow2;
-    ShadowParams shadow3;
+
+    void operator*=(qreal factor)
+    {
+        offset *= factor;
+        shadow1 *= factor;
+        shadow2 *= factor;
+    }
 };
 
 //* handle shadow pixmaps passed to window manager via X property
@@ -103,6 +114,9 @@ public:
 
     //* shadow params from size enum
     static CompositeShadowParams lookupShadowParams(int shadowSizeEnum);
+
+    //* shadow intensity params from intensity enum
+    static int lookupIntensityParams(int shadowIntensityEnum);
 
     //* reset
     void reset();
@@ -121,7 +135,7 @@ public:
 
     //* shadow tiles
     /** is public because it is also needed for mdi windows */
-    TileSet shadowTiles();
+    TileSet shadowTiles(QWidget *);
     static TileSet shadowTiles(const int frameRadius, CustomShadowParams shadow1, CustomShadowParams shadow2 = CustomShadowParams());
 
 protected Q_SLOTS:

--- a/libdarklycommon/darklyboxshadowrenderer.cpp
+++ b/libdarklycommon/darklyboxshadowrenderer.cpp
@@ -242,19 +242,19 @@ static inline void mirrorTopLeftQuadrant(QImage &image)
     }
 }
 
-static void renderShadow(QPainter *painter, const QRect &rect, qreal borderRadius, const QPoint &offset, int radius, const QColor &color)
+static void renderShadow(QPainter *painter, const QRectF &rect, qreal borderRadius, const QPointF &offset, double radius, const QColor &color)
 {
-    const QSize inflation = calculateBlurExtent(radius);
-    const QSize size = rect.size() + 2 * inflation;
-
     const qreal dpr = painter->device()->devicePixelRatioF();
+    const QSize inflation = calculateBlurExtent(radius);
+    const QSize pixelSize = ((rect.size() + 2 * inflation) * dpr).toSize();
+    const QSizeF size = QSizeF(pixelSize) / dpr;
 
-    QImage shadow(size * dpr, QImage::Format_ARGB32_Premultiplied);
+    QImage shadow(pixelSize, QImage::Format_ARGB32_Premultiplied);
     shadow.setDevicePixelRatio(dpr);
     shadow.fill(Qt::transparent);
 
-    QRect boxRect(QPoint(0, 0), rect.size());
-    boxRect.moveCenter(QRect(QPoint(0, 0), size).center());
+    QRectF boxRect(QPoint(0, 0), rect.size());
+    boxRect.moveCenter(QRectF(QPoint(0, 0), size).center());
 
     const qreal xRadius = 2.0 * borderRadius / boxRect.width();
     const qreal yRadius = 2.0 * borderRadius / boxRect.height();
@@ -271,8 +271,8 @@ static void renderShadow(QPainter *painter, const QRect &rect, qreal borderRadiu
 
     // Because the shadow texture is symmetrical, that's enough to blur
     // only the top-left quadrant and then mirror it.
-    const QRect blurRect(0, 0, qCeil(shadow.width() * 0.5), qCeil(shadow.height() * 0.5));
-    const int scaledRadius = qRound(radius * dpr);
+    const QRect blurRect(0, 0, std::ceil(shadow.width() * 0.5), std::ceil(shadow.height() * 0.5));
+    const int scaledRadius = std::round(radius * dpr);
     boxBlurAlpha(shadow, scaledRadius, blurRect);
     mirrorTopLeftQuadrant(shadow);
 
@@ -283,13 +283,13 @@ static void renderShadow(QPainter *painter, const QRect &rect, qreal borderRadiu
     shadowPainter.end();
 
     // Actually, present the shadow.
-    QRect shadowRect = shadow.rect();
+    QRectF shadowRect = shadow.rect();
     shadowRect.setSize(shadowRect.size() / dpr);
     shadowRect.moveCenter(rect.center() + offset);
     painter->drawImage(shadowRect, shadow);
 }
 
-void BoxShadowRenderer::setBoxSize(const QSize &size)
+void BoxShadowRenderer::setBoxSize(const QSizeF &size)
 {
     m_boxSize = size;
 }
@@ -299,12 +299,7 @@ void BoxShadowRenderer::setBorderRadius(qreal radius)
     m_borderRadius = radius;
 }
 
-void BoxShadowRenderer::setDevicePixelRatio(qreal dpr)
-{
-    m_dpr = dpr;
-}
-
-void BoxShadowRenderer::addShadow(const QPoint &offset, int radius, const QColor &color)
+void BoxShadowRenderer::addShadow(const QPointF &offset, double radius, const QColor &color)
 {
     Shadow shadow = {};
     shadow.offset = offset;
@@ -319,17 +314,16 @@ QImage BoxShadowRenderer::render() const
         return {};
     }
 
-    QSize canvasSize;
+    QSizeF canvasSize;
     for (const Shadow &shadow : std::as_const(m_shadows)) {
         canvasSize = canvasSize.expandedTo(calculateMinimumShadowTextureSize(m_boxSize, shadow.radius, shadow.offset));
     }
 
-    QImage canvas(canvasSize * m_dpr, QImage::Format_ARGB32_Premultiplied);
-    canvas.setDevicePixelRatio(m_dpr);
+    QImage canvas(canvasSize.toSize(), QImage::Format_ARGB32_Premultiplied);
     canvas.fill(Qt::transparent);
 
-    QRect boxRect(QPoint(0, 0), m_boxSize);
-    boxRect.moveCenter(QRect(QPoint(0, 0), canvasSize).center());
+    QRectF boxRect(QPoint(0, 0), m_boxSize);
+    boxRect.moveCenter(QRect(QPoint(0, 0), canvas.size()).center());
 
     QPainter painter(&canvas);
     for (const Shadow &shadow : std::as_const(m_shadows)) {
@@ -346,9 +340,9 @@ QSize BoxShadowRenderer::calculateMinimumBoxSize(int radius)
     return 2 * blurExtent + QSize(1, 1);
 }
 
-QSize BoxShadowRenderer::calculateMinimumShadowTextureSize(const QSize &boxSize, int radius, const QPoint &offset)
+QSizeF BoxShadowRenderer::calculateMinimumShadowTextureSize(const QSizeF &boxSize, double radius, const QPointF &offset)
 {
-    return boxSize + 2 * calculateBlurExtent(radius) + QSize(qAbs(offset.x()), qAbs(offset.y()));
+    return boxSize + 2 * calculateBlurExtent(radius) + QSizeF(std::abs(offset.x()), std::abs(offset.y()));
 }
 
 } // namespace Darkly

--- a/libdarklycommon/darklyboxshadowrenderer.h
+++ b/libdarklycommon/darklyboxshadowrenderer.h
@@ -39,7 +39,7 @@ public:
      * Set the size of the box.
      * @param size The size of the box.
      **/
-    void setBoxSize(const QSize &size);
+    void setBoxSize(const QSizeF &size);
 
     /**
      * Set the radius of box' corners.
@@ -48,18 +48,12 @@ public:
     void setBorderRadius(qreal radius);
 
     /**
-     * Set the device pixel ratio of the resulting shadow texture.
-     * @param dpr The device pixel ratio.
-     **/
-    void setDevicePixelRatio(qreal dpr);
-
-    /**
      * Add a shadow.
      * @param offset The offset of the shadow.
      * @param radius The blur radius.
      * @param color The color of the shadow.
      **/
-    void addShadow(const QPoint &offset, int radius, const QColor &color);
+    void addShadow(const QPointF &offset, double radius, const QColor &color);
 
     /**
      * Render the shadow.
@@ -86,16 +80,15 @@ public:
      * @param radius The blur radius.
      * @param offset The offset of the shadow.
      **/
-    static QSize calculateMinimumShadowTextureSize(const QSize &boxSize, int radius, const QPoint &offset);
+    static QSizeF calculateMinimumShadowTextureSize(const QSizeF &boxSize, double radius, const QPointF &offset);
 
 private:
-    QSize m_boxSize;
+    QSizeF m_boxSize;
     qreal m_borderRadius = 0.0;
-    qreal m_dpr = 1.0;
 
     struct Shadow {
-        QPoint offset;
-        int radius;
+        QPointF offset;
+        double radius;
         QColor color;
     };
 


### PR DESCRIPTION
Changes for #121 which details multiple issues with shadows.

The old [ShadowParams](https://github.com/Bali10050/Darkly/blob/05a945c69f0dd4bec8fc32331ba4d85819af1fcb/kstyle/darklyshadowhelper.cpp#L44)  do not work properly anymore causing problems with menu items and tooltips to render an extra shadow effect.

Brought in values used from Breeze and tested using different color-schemes.

New features added.

Added shadow settings tab which affect the menu control

- Control shadow strength - makes shadows bigger
- Control shadow color - changes the shadow color
- Control shadow intensity - makes the shadow thicker

**Shadow settings**

![shadow_settings](https://github.com/user-attachments/assets/d5103cab-3b67-44e7-a932-f61a8ed7589e)

**Tooltip shadow fixed**

![shadow_tooltip](https://github.com/user-attachments/assets/929396b5-3126-4166-82ff-068ede61178c)

**Menu shadow effect**

![shadow_global_menu](https://github.com/user-attachments/assets/6709df40-eecf-476f-b6d4-5b30498be15e)

I would advise testing this as this entails a lot of changes.

**Additionally, cleaned up the first settings page.**

![settings](https://github.com/user-attachments/assets/2bda2c3a-8895-48d8-8e30-c4d4825c0951)
