### PR TITLE
Opacity and blur background rework

### DIFF
--- a/kstyle/config/darklystyleconfig.cpp
+++ b/kstyle/config/darklystyleconfig.cpp
@@ -80,6 +80,10 @@ StyleConfig::StyleConfig(QWidget *parent)
     connect(_toolBarOpacity, SIGNAL(valueChanged(int)), _toolBarOpacitySpinBox, SLOT(setValue(int)));
     connect(_toolBarOpacitySpinBox, SIGNAL(valueChanged(int)), _toolBarOpacity, SLOT(setValue(int)));
 
+    connect(_tabBarOpacity, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
+    connect(_tabBarOpacity, SIGNAL(valueChanged(int)), _tabBarOpacitySpinBox, SLOT(setValue(int)));
+    connect(_tabBarOpacitySpinBox, SIGNAL(valueChanged(int)), _tabBarOpacity, SLOT(setValue(int)));
+
     connect(_kTextEditDrawFrame, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
 
     connect(_widgetDrawShadow, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
@@ -126,6 +130,7 @@ void StyleConfig::save()
     StyleConfigData::setDolphinSidebarOpacity(_sidebarOpacity->value());
     StyleConfigData::setMenuBarOpacity(_menuBarOpacity->value());
     StyleConfigData::setToolBarOpacity(_toolBarOpacity->value());
+    StyleConfigData::setTabBarOpacity(_tabBarOpacity->value());
     StyleConfigData::setButtonSize(_buttonSize->value());
     StyleConfigData::setKTextEditDrawFrame(_kTextEditDrawFrame->isChecked());
     StyleConfigData::setWidgetDrawShadow(_widgetDrawShadow->isChecked());
@@ -221,6 +226,9 @@ void StyleConfig::updateChanged()
     } else if (_toolBarOpacity->value() != StyleConfigData::toolBarOpacity()) {
         modified = true;
         _toolBarOpacitySpinBox->setValue(_toolBarOpacity->value());
+    } else if (_tabBarOpacity->value() != StyleConfigData::tabBarOpacity()) {
+        modified = true;
+        _tabBarOpacitySpinBox->setValue(_tabBarOpacity->value());
     } else if (_kTextEditDrawFrame->isChecked() != StyleConfigData::kTextEditDrawFrame())
         modified = true;
     else if (_tabBarDrawCenteredTabs->isChecked() != StyleConfigData::tabBarDrawCenteredTabs())
@@ -274,6 +282,12 @@ void StyleConfig::updateChanged()
         _widgetToolBarShadow->setEnabled(true);
     }
 
+    if (_adjustToDarkThemes->isChecked()) {
+        _tabBGColor->setEnabled(true);
+    } else {
+        _tabBGColor->setEnabled(false);
+    }
+
     emit changed(modified);
 }
 
@@ -305,6 +319,8 @@ void StyleConfig::load()
     _menuBarOpacitySpinBox->setValue(StyleConfigData::menuBarOpacity());
     _toolBarOpacity->setValue(StyleConfigData::toolBarOpacity());
     _toolBarOpacitySpinBox->setValue(StyleConfigData::toolBarOpacity());
+    _tabBarOpacity->setValue(StyleConfigData::tabBarOpacity());
+    _tabBarOpacitySpinBox->setValue(StyleConfigData::tabBarOpacity());
 
     _buttonSize->setValue(StyleConfigData::buttonSize());
     _kTextEditDrawFrame->setChecked(StyleConfigData::kTextEditDrawFrame());
@@ -334,12 +350,21 @@ void StyleConfig::load()
         _shadowIntensity->setEnabled(false);
         _shadowStrength->setEnabled(false);
     }
+
+    _adjustToDarkThemes->setChecked(StyleConfigData::adjustToDarkThemes());
+
+    if (_adjustToDarkThemes->isChecked()) {
+        _tabBGColor->setEnabled(true);
+    } else {
+        _tabBGColor->setEnabled(false);
+    }
+
     _shadowColor->setColor(StyleConfigData::shadowColor());
     _shadowStrength->setValue(StyleConfigData::shadowStrength());
     _shadowIntensity->setCurrentIndex(StyleConfigData::shadowIntensity());
     _scrollableMenu->setChecked(StyleConfigData::scrollableMenu());
     _oldTabbar->setChecked(StyleConfigData::oldTabbar());
-    _adjustToDarkThemes->setChecked(StyleConfigData::adjustToDarkThemes());
+
     _tabBarAltStyle->setChecked(StyleConfigData::tabBarAltStyle());
     _tabBGColor->setColor(StyleConfigData::tabBGColor());
     _transparentDolphinView->setChecked(StyleConfigData::transparentDolphinView());

--- a/kstyle/config/ui/darklystyleconfig.ui
+++ b/kstyle/config/ui/darklystyleconfig.ui
@@ -362,7 +362,7 @@
         <widget class="QLabel" name="_versionNumber">
          <property name="font">
           <font>
-           <bold>true</bold>
+           <bold>false</bold>
           </font>
          </property>
          <property name="layoutDirection">
@@ -986,6 +986,113 @@
        <string>Transparency</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="label_6">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Transparent</string>
+           </property>
+           <property name="indent">
+            <number>73</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LayoutDirection::LeftToRight</enum>
+           </property>
+           <property name="text">
+            <string>Opaque</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="margin">
+            <number>0</number>
+           </property>
+           <property name="indent">
+            <number>93</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="7" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_22">
+         <item>
+          <widget class="QLabel" name="label_18">
+           <property name="text">
+            <string>Tabbar:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+           <property name="buddy">
+            <cstring>_tabBarOpacity</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_23">
+           <property name="leftMargin">
+            <number>10</number>
+           </property>
+           <item>
+            <widget class="QSlider" name="_tabBarOpacity">
+             <property name="toolTip">
+              <string>This changes the tabbar opacity inside Dolphin &amp; Konsole</string>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="tickPosition">
+              <enum>QSlider::TickPosition::TicksBelow</enum>
+             </property>
+             <property name="tickInterval">
+              <number>10</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="_tabBarOpacitySpinBox">
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
        <item row="4" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_7">
          <item>
@@ -1051,57 +1158,15 @@
          </item>
         </layout>
        </item>
-       <item row="0" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout">
+       <item row="6" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
-          <widget class="QLabel" name="label_6">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+          <widget class="QLabel" name="label_8">
+           <property name="enabled">
+            <bool>true</bool>
            </property>
            <property name="text">
-            <string>Transparent</string>
-           </property>
-           <property name="indent">
-            <number>73</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="layoutDirection">
-            <enum>Qt::LayoutDirection::LeftToRight</enum>
-           </property>
-           <property name="text">
-            <string>Opaque</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-           <property name="margin">
-            <number>0</number>
-           </property>
-           <property name="indent">
-            <number>93</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="2" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
-         <item>
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Si&amp;debar:</string>
+            <string>Toolbar:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1110,12 +1175,12 @@
             <number>5</number>
            </property>
            <property name="buddy">
-            <cstring>_sidebarOpacity</cstring>
+            <cstring>_toolBarOpacity</cstring>
            </property>
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_9">
+          <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0">
            <property name="spacing">
             <number>0</number>
            </property>
@@ -1123,33 +1188,18 @@
             <number>10</number>
            </property>
            <item>
-            <widget class="QSlider" name="_sidebarOpacity">
+            <widget class="QSlider" name="_toolBarOpacity">
              <property name="toolTip">
-              <string>This changes the Dolphin sidebar transparency</string>
+              <string>This changes the toolbar opacity</string>
              </property>
              <property name="maximum">
               <number>100</number>
              </property>
-             <property name="singleStep">
-              <number>1</number>
-             </property>
-             <property name="pageStep">
-              <number>10</number>
-             </property>
              <property name="value">
-              <number>100</number>
-             </property>
-             <property name="sliderPosition">
               <number>100</number>
              </property>
              <property name="orientation">
               <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="invertedAppearance">
-              <bool>false</bool>
-             </property>
-             <property name="invertedControls">
-              <bool>false</bool>
              </property>
              <property name="tickPosition">
               <enum>QSlider::TickPosition::TicksBelow</enum>
@@ -1162,7 +1212,7 @@
           </layout>
          </item>
          <item>
-          <widget class="QSpinBox" name="_sidebarOpacitySpinBox">
+          <widget class="QSpinBox" name="_toolBarOpacitySpinBox">
            <property name="alignment">
             <set>Qt::AlignmentFlag::AlignCenter</set>
            </property>
@@ -1256,15 +1306,12 @@
          </item>
         </layout>
        </item>
-       <item row="6" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item row="2" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
          <item>
-          <widget class="QLabel" name="label_8">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
+          <widget class="QLabel" name="label_5">
            <property name="text">
-            <string>Toolbar:</string>
+            <string>Si&amp;debar:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -1273,12 +1320,12 @@
             <number>5</number>
            </property>
            <property name="buddy">
-            <cstring>_toolBarOpacity</cstring>
+            <cstring>_sidebarOpacity</cstring>
            </property>
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_9">
            <property name="spacing">
             <number>0</number>
            </property>
@@ -1286,18 +1333,33 @@
             <number>10</number>
            </property>
            <item>
-            <widget class="QSlider" name="_toolBarOpacity">
+            <widget class="QSlider" name="_sidebarOpacity">
              <property name="toolTip">
-              <string>This changes the toolbar opacity</string>
+              <string>This changes the Dolphin sidebar transparency</string>
              </property>
              <property name="maximum">
               <number>100</number>
              </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="pageStep">
+              <number>10</number>
+             </property>
              <property name="value">
+              <number>100</number>
+             </property>
+             <property name="sliderPosition">
               <number>100</number>
              </property>
              <property name="orientation">
               <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="invertedAppearance">
+              <bool>false</bool>
+             </property>
+             <property name="invertedControls">
+              <bool>false</bool>
              </property>
              <property name="tickPosition">
               <enum>QSlider::TickPosition::TicksBelow</enum>
@@ -1310,7 +1372,7 @@
           </layout>
          </item>
          <item>
-          <widget class="QSpinBox" name="_toolBarOpacitySpinBox">
+          <widget class="QSpinBox" name="_sidebarOpacitySpinBox">
            <property name="alignment">
             <set>Qt::AlignmentFlag::AlignCenter</set>
            </property>
@@ -1324,7 +1386,7 @@
          </item>
         </layout>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>

--- a/kstyle/darkly.h
+++ b/kstyle/darkly.h
@@ -261,6 +261,12 @@ enum ButtonType {
     ButtonRestore
 };
 
+// toolbar, menubar, tabbar opacity
+enum BarType {
+    MenuBar,
+    ToolBar,
+    TabBar
+};
 }
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Darkly::AnimationModes)

--- a/kstyle/darkly.kcfg
+++ b/kstyle/darkly.kcfg
@@ -298,6 +298,10 @@
         <default>100</default>
     </entry>
 
+     <entry name="TabBarOpacity" type="Int">
+        <default>100</default>
+    </entry>
+
     <entry name="AdjustToDarkThemes" type="Bool">
       <default>false</default>
     </entry>

--- a/kstyle/darklyblurhelper.cpp
+++ b/kstyle/darklyblurhelper.cpp
@@ -323,10 +323,7 @@ QRegion BlurHelper::blurTabWidgetRegion(QWidget *widget) const
     // tabs lock down to only only blur dolphin / konsole
     if (QTabWidget *tabWidget = widget->findChild<QTabWidget *>()) {
         if (_isDolphin) {
-            // check if Dolphin URL location is editable otherwise transparency creates a visible line underneath
-
             tabWidgetRect = QRect(widget->pos(), widget->rect().size());
-
         } else {
             if (tabWidget->parentWidget()->inherits("Konsole::MainWindow")) {
                 tabWidgetRect = QRect(widget->pos(), widget->rect().size());

--- a/kstyle/darklyblurhelper.cpp
+++ b/kstyle/darklyblurhelper.cpp
@@ -326,7 +326,6 @@ QRegion BlurHelper::blurTabWidgetRegion(QWidget *widget) const
                 } else {
                     // region += QRect(pos, rect.size());
                     region += roundedRegion(QRect(pos, rect.size()), StyleConfigData::cornerRadius(), false, false, true, false);
-                    qDebug() << "closed = " << rect.size();
                 }
             }
         } else if (w->inherits("DolphinTabWidget") || w->inherits("Konsole::TabbedViewContainer")) {

--- a/kstyle/darklyblurhelper.cpp
+++ b/kstyle/darklyblurhelper.cpp
@@ -34,6 +34,7 @@
 
 #include <KWindowEffects>
 
+#include <QComboBox>
 #include <QEvent>
 #include <QMainWindow>
 #include <QMenu>
@@ -196,7 +197,7 @@ QRegion BlurHelper::blurRegion(QWidget *widget) const
                         orientation = tb->orientation();
                     }
 
-                    // test against the previous best caditate
+                    // test against the previous best candidate
                     else {
                         if ((tb->y() < mainToolbar.y()) || (tb->y() == mainToolbar.y() && tb->x() < mainToolbar.x())) {
                             mainToolbar = QRect(tb->pos(), tb->rect().size());
@@ -272,20 +273,7 @@ QRegion BlurHelper::blurRegion(QWidget *widget) const
                 }
 
                 // settings page
-                if ((widget->windowFlags() & Qt::WindowType_Mask) == Qt::Dialog) {
-                    QList<QWidget *> dialogWidgets = widget->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly);
-                    for (auto w : dialogWidgets) {
-                        if (w->inherits("KPageWidget")) {
-                            QList<QWidget *> KPageWidgets = w->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly);
-                            for (auto wid : KPageWidgets) {
-                                if (wid->property(PropertyNames::sidePanelView).toBool()) {
-                                    region += roundedRegion(QRect(wid->pos(), wid->rect().size()), StyleConfigData::cornerRadius(), false, false, true, false);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
+                // moved to blur tabs wiget region
             }
 
             /*if( (widget->windowFlags() & Qt::WindowType_Mask) == Qt::Dialog )
@@ -318,21 +306,55 @@ QRegion BlurHelper::blurRegion(QWidget *widget) const
 QRegion BlurHelper::blurTabWidgetRegion(QWidget *widget) const
 {
     QRegion region;
-    QRect tabWidgetRect = QRect();
+    // QRect tabWidgetRect = QRect();
 
-    // tabs lock down to only only blur dolphin / konsole
-    if (QTabWidget *tabWidget = widget->findChild<QTabWidget *>()) {
-        if (_isDolphin) {
-            tabWidgetRect = QRect(widget->pos(), widget->rect().size());
-        } else {
-            if (tabWidget->parentWidget()->inherits("Konsole::MainWindow")) {
-                tabWidgetRect = QRect(widget->pos(), widget->rect().size());
+    // tabs lock down to only only blur dolphin / konsole main windows
+
+    QList<QWidget *> widgets = widget->findChildren<QWidget *>();
+
+    for (auto w : widgets) {
+        auto rect = w->rect();
+        auto pos = w->pos();
+        // location bar area
+        if (w->inherits("DolphinUrlNavigator")) {
+            // dolphin location bar
+            if (auto locationBar = w->findChild<QComboBox *>()) {
+                if (locationBar->isVisible()) {
+                    // double the rect size else it leaves an unblurred line underneath the toolbar
+                    region += roundedRegion(QRect(pos, rect.size() * 2), StyleConfigData::cornerRadius(), false, false, true, false);
+
+                } else {
+                    // region += QRect(pos, rect.size());
+                    region += roundedRegion(QRect(pos, rect.size()), StyleConfigData::cornerRadius(), false, false, true, false);
+                    qDebug() << "closed = " << rect.size();
+                }
             }
+        } else if (w->inherits("DolphinTabWidget") || w->inherits("Konsole::TabbedViewContainer")) {
+            // tabs
+            region += roundedRegion(QRect(pos, rect.size()), StyleConfigData::cornerRadius(), false, false, true, false);
         }
     }
 
-    if (tabWidgetRect.isValid()) {
-        region += tabWidgetRect;
+    // settings
+    if ((widget->windowFlags() & Qt::WindowType_Mask) == Qt::Dialog) {
+        for (auto w : widgets) {
+            if (qobject_cast<QTabWidget *>(w)) {
+                // settings main dialog
+                region += roundedRegion(QRect(w->mapToGlobal(w->pos()), w->rect().size()), StyleConfigData::cornerRadius(), false, false, true, false);
+            } else if (widget->inherits("KAboutApplicationDialog") || widget->inherits("KDEPrivate::KAboutKdeDialog")) {
+                // about dialog
+                region += roundedRegion(QRect(w->pos(), w->rect().size()), StyleConfigData::cornerRadius(), false, false, true, false);
+            } else if (w->inherits("KPageWidget")) {
+                // sidebar
+                QList<QWidget *> KPageWidgets = w->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly);
+                for (auto wid : KPageWidgets) {
+                    if (wid->property(PropertyNames::sidePanelView).toBool()) {
+                        region += roundedRegion(QRect(wid->pos(), wid->rect().size()), StyleConfigData::cornerRadius(), false, false, true, false);
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     return region;

--- a/kstyle/darklyblurhelper.h
+++ b/kstyle/darklyblurhelper.h
@@ -80,6 +80,8 @@ protected:
     //! handle blur region
     QRegion blurRegion(QWidget *widget) const;
 
+    QRegion blurTabWidgetRegion(QWidget *widget) const;
+
     //! update blur regions for given widget
     void update(QWidget *) const;
 

--- a/kstyle/darklyhelper.cpp
+++ b/kstyle/darklyhelper.cpp
@@ -1814,8 +1814,7 @@ bool Helper::hasAlphaChannel(const QWidget *widget) const
 //____________________________________________________________________
 bool Helper::shouldWindowHaveAlpha(const QPalette &palette, bool isDolphin) const
 {
-    if (_activeTitleBarColor.alphaF() < 1.0 || (StyleConfigData::dolphinSidebarOpacity() < 100 && isDolphin) || palette.color(QPalette::Window).alpha() < 255
-        || (StyleConfigData::toolBarOpacity() < 100) || (StyleConfigData::menuBarOpacity() < 100)) {
+    if (_activeTitleBarColor.alphaF() < 1.0 || (StyleConfigData::dolphinSidebarOpacity() < 100 && isDolphin) || palette.color(QPalette::Window).alpha() < 255) {
         return true;
     }
     return false;
@@ -1888,4 +1887,58 @@ bool Helper::shouldDrawToolsArea(const QWidget *widget) const
     }
     return true;
 }
+
+//______________________________________________________________________________________
+QColor Helper::transparentBarBgColor(QColor bgColor, QPainter *painter, const QRect &rect, BarType barType) const
+{
+    switch (barType) {
+    case BarType::MenuBar: {
+        if (StyleConfigData::menuBarOpacity() == 100) {
+            // opacity is at 100%
+            bgColor.setAlphaF(1.0);
+        } else if (StyleConfigData::menuBarOpacity() == 0) {
+            // fully transparent
+            bgColor.setAlphaF(0.0);
+            renderTransparentArea(painter, rect);
+        } else if (StyleConfigData::menuBarOpacity() < 100 && StyleConfigData::menuBarOpacity() > 0) {
+            // lower the opacity
+            bgColor.setAlphaF(StyleConfigData::menuBarOpacity() / 100.0);
+            renderTransparentArea(painter, rect);
+        }
+        return bgColor;
+    }
+    case BarType::ToolBar: {
+        if (StyleConfigData::toolBarOpacity() == 100) {
+            // opacity is at 100%
+            bgColor.setAlphaF(1.0);
+        } else if (StyleConfigData::toolBarOpacity() == 0) {
+            // fully transparent
+            bgColor.setAlphaF(0.0);
+            renderTransparentArea(painter, rect);
+        } else if (StyleConfigData::toolBarOpacity() < 100 && StyleConfigData::toolBarOpacity() > 0) {
+            // lower the opacity
+            bgColor.setAlphaF(StyleConfigData::toolBarOpacity() / 100.0);
+            renderTransparentArea(painter, rect);
+        }
+        return bgColor;
+    }
+    case BarType::TabBar: {
+        if (StyleConfigData::tabBarOpacity() == 100) {
+            // opacity is at 100%
+            bgColor.setAlphaF(1.0);
+        } else if (StyleConfigData::tabBarOpacity() == 0) {
+            // fully transparent
+            bgColor.setAlphaF(0.0);
+            renderTransparentArea(painter, rect);
+        } else if (StyleConfigData::tabBarOpacity() < 100 && StyleConfigData::tabBarOpacity() > 0) {
+            // lower the opacity
+            bgColor.setAlphaF(StyleConfigData::tabBarOpacity() / 100.0);
+            renderTransparentArea(painter, rect);
+        }
+        return bgColor;
+    }
+    default:
+        return bgColor;
+    }
 }
+} // namespace

--- a/kstyle/darklyhelper.h
+++ b/kstyle/darklyhelper.h
@@ -432,6 +432,9 @@ public:
                         QIcon::Mode mode = QIcon::Normal,
                         QIcon::State state = QIcon::Off);
 
+    // MenuBar, ToolBar, TabBar background color opacity
+    QColor transparentBarBgColor(QColor, QPainter *, const QRect &, BarType) const;
+
 protected:
     //* return rounded path in a given rect, with only selected corners rounded, and for a given radius
     QPainterPath roundedPath(const QRectF &, Corners, qreal) const;

--- a/kstyle/darklystyle.cpp
+++ b/kstyle/darklystyle.cpp
@@ -325,8 +325,9 @@ void Style::polish(QWidget *widget)
             break;
         }
 
-        if (!_helper->shouldWindowHaveAlpha(widget->palette(), _isDolphin) || _isOpaque)
+        if (!_helper->shouldWindowHaveAlpha(widget->palette(), _isDolphin) || _isOpaque) {
             break;
+        }
 
         /* take all precautions */
         if (!_subApp && !_isLibreoffice && widget->isWindow() && widget->windowType() != Qt::Desktop && !widget->testAttribute(Qt::WA_PaintOnScreen)
@@ -474,6 +475,13 @@ void Style::polish(QWidget *widget)
         widget->setAttribute(Qt::WA_StyledBackground);
     } else if (qobject_cast<QDialogButtonBox *>(widget)) {
         addEventFilter(widget);
+
+        // opaque menubar / toolbar / tabbar
+
+    } else if (qobject_cast<QToolBar *>(widget) || qobject_cast<QMenuBar *>(widget) || qobject_cast<QTabWidget *>(widget)) {
+        if (StyleConfigData::toolBarOpacity() < 100 || StyleConfigData::menuBarOpacity() < 100 || StyleConfigData::tabBarOpacity() < 100) {
+            _blurHelper->registerWidget(widget->window(), _isDolphin);
+        }
     }
 
     if (_toolsAreaManager->hasHeaderColors()) {
@@ -1191,7 +1199,7 @@ bool Style::drawWidgetPrimitive(const QStyleOption *option, QPainter *painter, c
     if (mw && mw == mw->window()) {
         painter->save();
 
-        auto rect = _toolsAreaManager->toolsAreaRect(mw);
+        auto rect = _toolsAreaManager->toolsAreaRect(*mw);
 
         if (rect.height() == 0) {
             if (mw->property(PropertyNames::noSeparator).toBool() || mw->isFullScreen()) {
@@ -2469,16 +2477,18 @@ QRect Style::tabWidgetTabBarRect(const QStyleOption *option, const QWidget *widg
         rect.setLeft(leftButtonRect.width() + (documentMode ? 0 : Metrics::Frame_FrameWidth));
         rect.setRight(rightButtonRect.left() + (documentMode ? 0 : Metrics::Frame_FrameWidth));
         const int sizeCorrection = -1; // HACK: for some reason, the rect size is 1px larger than expected, so it needs to be reduced
-        if (StyleConfigData::tabBarTabExpandFullWidth())
+        if (StyleConfigData::tabBarTabExpandFullWidth() && StyleConfigData::tabBarOpacity() == 100) {
             tabBarRect.setWidth(rect.width() - 2 * Metrics::Frame_FrameWidth - sizeCorrection); // adwaita qt style tab
-        else
+        } else {
             tabBarRect.setWidth(qMin(tabBarRect.width(), rect.width() - 2)); // fixed width tabs
-        if (tabBarAlignment == Qt::AlignCenter)
+        }
+        if (tabBarAlignment == Qt::AlignCenter) {
             tabBarRect.moveLeft(rect.left() + (rect.width() - tabBarRect.width()) / 2);
-        else if (tabOption->lineWidth == 0)
+        } else if (tabOption->lineWidth == 0) {
             tabBarRect.moveLeft(rect.left() + 4);
-        else
+        } else {
             tabBarRect.moveLeft(rect.left() - 1);
+        }
 
         tabBarRect = visualRect(option, tabBarRect);
     }
@@ -3775,6 +3785,39 @@ bool Style::drawFrameLineEditPrimitive(const QStyleOption *option, QPainter *pai
     // store window state
     const bool windowActive(widget && widget->isActiveWindow());
 
+    auto background = palette.color(QPalette::Base);
+    auto outline(palette.color(QPalette::Highlight));
+
+    bool isVisible = false;
+
+    // take precautions only change this on the Dolphin location bar
+    if (_isDolphin && widget->inherits("DolphinUrlNavigator")) {
+        // check if the Dolphin URL location bar is visible
+
+        // only change the alpha channel if the  Dolphin URL location bar is hidden
+        // otherwise the rectangle doesn't render rounded eges
+
+        if (widget->findChild<QComboBox *>()) {
+            isVisible = widget->findChild<QComboBox *>()->isVisible();
+
+            if (!isVisible) {
+                // breadcrumb view not editable location
+                if (StyleConfigData::toolBarOpacity() < 100) {
+                    background.setAlphaF(StyleConfigData::toolBarOpacity() / 100);
+                }
+                // URL location path
+                QLineEdit *dolphinLineEdit = widget->findChild<QLineEdit *>();
+                ;
+                // change the background to make it opaque aswell
+                if (dolphinLineEdit) {
+                    QPalette pal(dolphinLineEdit->palette());
+                    pal.setColor(QPalette::Window, background);
+                    dolphinLineEdit->setPalette(pal);
+                }
+            }
+        }
+    }
+
     // make sure there is enough room to render frame
     if (rect.height() < 2 * Metrics::LineEdit_FrameWidth + option->fontMetrics.height()) {
         const auto &background = palette.color(QPalette::Base);
@@ -3796,12 +3839,12 @@ bool Style::drawFrameLineEditPrimitive(const QStyleOption *option, QPainter *pai
         //_animations->inputWidgetEngine().updateState( widget, AnimationHover, mouseOver && !hasFocus );
 
         // retrieve animation mode and opacity
-        const AnimationMode mode(_animations->inputWidgetEngine().frameAnimationMode(widget));
-        const qreal opacity(_animations->inputWidgetEngine().frameOpacity(widget));
+        AnimationMode mode(_animations->inputWidgetEngine().frameAnimationMode(widget));
+        qreal opacity(_animations->inputWidgetEngine().frameOpacity(widget));
+
+        // Fix needed: if Dolphin location is Editable
 
         // render
-        const auto &background = palette.color(QPalette::Base);
-        const auto outline(palette.color(QPalette::Highlight));
         _helper->renderLineEdit(painter, rect, background, outline, hasFocus, mouseOver, enabled, windowActive, mode, opacity);
     }
 
@@ -3933,48 +3976,59 @@ bool Style::drawFrameTabWidgetPrimitive(const QStyleOption *option, QPainter *pa
 }
 
 //___________________________________________________________________________________
-bool Style::drawFrameTabBarBasePrimitive(const QStyleOption *option, QPainter *painter, const QWidget *) const
+bool Style::drawFrameTabBarBasePrimitive(const QStyleOption *option, QPainter *painter, const QWidget *widget) const
 {
     // tabbar frame used either for 'separate' tabbar, or in 'document mode'
 
+    // this is the empty part of the tab area
+
     // cast option and check
     const auto tabOption(qstyleoption_cast<const QStyleOptionTabBarBase *>(option));
+    // get rect, orientation, palette
+    const auto rect(option->rect);
+
     if (!tabOption)
         return true;
 
-    // get rect, orientation, palette
-    const auto rect(option->rect);
-    const auto outline(QColor(0, 0, 0, 1));
-
     // setup painter
-    painter->setBrush(Qt::NoBrush);
     painter->setRenderHint(QPainter::Antialiasing, false);
-    painter->setPen(QPen(outline, 1));
 
-    // render
-    switch (tabOption->shape) {
-    case QTabBar::RoundedNorth:
-    case QTabBar::TriangularNorth:
-        painter->drawLine(rect.bottomLeft() - QPoint(1, 0), rect.bottomRight() + QPoint(1, 0));
-        break;
+    // precaution don't change the alpha channel if the tabbar opacity is at 100
+    if ((_isDolphin || _isKonsole) && StyleConfigData::tabBarOpacity() < 100) {
+        QColor backgroundColor = _helper->transparentBarBgColor(widget->palette().color(QPalette::Window), painter, widget->rect(), BarType::TabBar);
+        painter->setBrush(backgroundColor);
+        painter->fillRect(rect, backgroundColor);
+    } else {
+        const auto outline(QColor(0, 0, 0, 1));
 
-    case QTabBar::RoundedSouth:
-    case QTabBar::TriangularSouth:
-        painter->drawLine(rect.topLeft() - QPoint(1, 0), rect.topRight() + QPoint(1, 0));
-        break;
+        painter->setBrush(Qt::NoBrush);
+        painter->setPen(QPen(outline, 1));
 
-    case QTabBar::RoundedWest:
-    case QTabBar::TriangularWest:
-        painter->drawLine(rect.topRight() - QPoint(0, 1), rect.bottomRight() + QPoint(1, 0));
-        break;
+        // render
+        switch (tabOption->shape) {
+        case QTabBar::RoundedNorth:
+        case QTabBar::TriangularNorth:
+            painter->drawLine(rect.bottomLeft() - QPoint(1, 0), rect.bottomRight() + QPoint(1, 0));
+            break;
 
-    case QTabBar::RoundedEast:
-    case QTabBar::TriangularEast:
-        painter->drawLine(rect.topLeft() - QPoint(0, 1), rect.bottomLeft() + QPoint(1, 0));
-        break;
+        case QTabBar::RoundedSouth:
+        case QTabBar::TriangularSouth:
+            painter->drawLine(rect.topLeft() - QPoint(1, 0), rect.topRight() + QPoint(1, 0));
+            break;
 
-    default:
-        break;
+        case QTabBar::RoundedWest:
+        case QTabBar::TriangularWest:
+            painter->drawLine(rect.topRight() - QPoint(0, 1), rect.bottomRight() + QPoint(1, 0));
+            break;
+
+        case QTabBar::RoundedEast:
+        case QTabBar::TriangularEast:
+            painter->drawLine(rect.topLeft() - QPoint(0, 1), rect.bottomLeft() + QPoint(1, 0));
+            break;
+
+        default:
+            break;
+        }
     }
 
     return true;
@@ -4264,7 +4318,21 @@ bool Style::drawTabBarPanelButtonToolPrimitive(const QStyleOption *option, QPain
 
     // render flat background
     painter->setPen(Qt::NoPen);
-    painter->setBrush(color);
+
+    if (_isDolphin || _isKonsole) {
+        // change background color alpha channel
+        if (StyleConfigData::tabBarOpacity() < 100) {
+            // override the tab background color
+            QColor tabBgColor = widget->palette().color(QPalette::Window);
+            tabBgColor = _helper->transparentBarBgColor(tabBgColor, painter, rect, BarType::TabBar);
+            painter->setBrush(tabBgColor);
+        } else {
+            painter->setBrush(color);
+        }
+
+    } else {
+        painter->setBrush(color);
+    }
     painter->drawRect(rect);
 
     return true;
@@ -5247,20 +5315,8 @@ bool Style::drawMenuBarEmptyAreaControl(const QStyleOption *option, QPainter *pa
     QColor opacityBackground(_toolsAreaManager->palette().color(QPalette::Window));
 
     // changes menubar background opacity
-
-    if (StyleConfigData::menuBarOpacity() == 100) {
-        // opacity is at 100%
-        opacityBackground.setAlpha(1.0);
-        painter->fillRect(rect, opacityBackground);
-    } else if (StyleConfigData::menuBarOpacity() == 0) {
-        // fully transparent
-        _helper->renderTransparentArea(painter, rect);
-        opacityBackground.setAlphaF(0.0);
-        painter->fillRect(rect, opacityBackground);
-    } else if (StyleConfigData::menuBarOpacity() < 100 && StyleConfigData::menuBarOpacity() > 0) {
-        // lower the opacity
-        _helper->renderTransparentArea(painter, rect);
-        opacityBackground.setAlphaF(StyleConfigData::menuBarOpacity() / 100.0);
+    if (StyleConfigData::menuBarOpacity() < 100) {
+        opacityBackground = _helper->transparentBarBgColor(opacityBackground, painter, rect, BarType::MenuBar);
         painter->fillRect(rect, opacityBackground);
     }
 
@@ -5332,20 +5388,8 @@ bool Style::drawMenuBarItemControl(const QStyleOption *option, QPainter *painter
     QColor opacityBackground(_toolsAreaManager->palette().color(QPalette::Window));
 
     // changes menubar background opacity
-
-    if (StyleConfigData::menuBarOpacity() == 100) {
-        // opacity is at 100%
-        opacityBackground.setAlpha(1.0);
-        painter->fillRect(rect, opacityBackground);
-    } else if (StyleConfigData::menuBarOpacity() == 0) {
-        // fully transparent
-        _helper->renderTransparentArea(painter, rect);
-        opacityBackground.setAlphaF(0.0);
-        painter->fillRect(rect, opacityBackground);
-    } else if (StyleConfigData::menuBarOpacity() < 100 && StyleConfigData::menuBarOpacity() > 0) {
-        // lower the opacity
-        _helper->renderTransparentArea(painter, rect);
-        opacityBackground.setAlphaF(StyleConfigData::menuBarOpacity() / 100.0);
+    if (StyleConfigData::menuBarOpacity() < 100) {
+        opacityBackground = _helper->transparentBarBgColor(opacityBackground, painter, rect, BarType::MenuBar);
         painter->fillRect(rect, opacityBackground);
     }
 
@@ -5766,21 +5810,12 @@ bool Style::drawToolBarBackgroundControl(const QStyleOption *option, QPainter *p
 
     // changes toolbar background opacity
 
-    if (StyleConfigData::toolBarOpacity() == 100) {
-        // opacity is at 100%
-        opacityBackground.setAlpha(1.0);
-        painter->fillRect(rect, opacityBackground);
-    } else if (StyleConfigData::toolBarOpacity() == 0) {
-        // fully transparent
-        _helper->renderTransparentArea(painter, rect);
-        opacityBackground.setAlphaF(0.0);
-        painter->fillRect(rect, opacityBackground);
-    } else if (StyleConfigData::toolBarOpacity() < 100 && StyleConfigData::toolBarOpacity() > 0) {
-        // lower the opacity
-        _helper->renderTransparentArea(painter, rect);
-        opacityBackground.setAlphaF(StyleConfigData::toolBarOpacity() / 100.0);
+    if (StyleConfigData::toolBarOpacity() < 100) {
+        opacityBackground = _helper->transparentBarBgColor(opacityBackground, painter, rect, BarType::ToolBar);
         painter->fillRect(rect, opacityBackground);
     }
+
+    // painter->fillRect(rect, backgroundColor);
 
     if (sideToolbarDolphin && _isDolphin) {
         backgroundColor.setAlphaF(StyleConfigData::dolphinSidebarOpacity() / 100.0 - 0.15);
@@ -6712,10 +6747,20 @@ bool Style::drawTabBarTabShapeControl(const QStyleOption *option, QPainter *pain
     documentMode |= (tabWidget ? tabWidget->documentMode() : true);
 
     // define the 'tabbar' background color
-    QColor ColorOfBackground =  StyleConfigData::adjustToDarkThemes() ? QColor(StyleConfigData::tabBGColor()/*0, 0, 0, 160*/) : palette.color(QPalette::Shadow);
+    QColor configTabBgColor = StyleConfigData::adjustToDarkThemes() ? QColor(StyleConfigData::tabBGColor() /*0, 0, 0, 160*/) : palette.color(QPalette::Shadow);
     QColor backgroundColor = documentMode
-    ? _helper->isDarkTheme(palette) ? _helper->alphaColor(ColorOfBackground, 0.4) : _helper->alphaColor(ColorOfBackground, 0.2)
-    : _helper->alphaColor(ColorOfBackground, 0.1);
+        ? _helper->isDarkTheme(palette) ? _helper->alphaColor(configTabBgColor, 0.4) : _helper->alphaColor(configTabBgColor, 0.2)
+        : _helper->alphaColor(configTabBgColor, 0.1);
+
+    // opacity only target dolphin and konsole
+    if ((_isDolphin || _isKonsole) && StyleConfigData::tabBarOpacity() < 100) {
+        // override the tab background color if adjustToDarkThemes is false
+        if (StyleConfigData::adjustToDarkThemes()) {
+            backgroundColor = _helper->transparentBarBgColor(backgroundColor, painter, rect, BarType::TabBar);
+        } else {
+            backgroundColor = _helper->transparentBarBgColor(_toolsAreaManager->palette().color(QPalette::Window), painter, rect, BarType::TabBar);
+        }
+    }
 
     // shadow size
     constexpr int shadowSize = 4;
@@ -8526,8 +8571,9 @@ void Style::setSurfaceFormat(QWidget *widget) const
     }
 
     else {
-        if (_isPlasma || _isOpaque || !widget->isWindow() || !_helper->shouldWindowHaveAlpha(widget->palette(), _isDolphin))
+        if (_isPlasma || _isOpaque || !widget->isWindow() || !_helper->shouldWindowHaveAlpha(widget->palette(), _isDolphin)) {
             return;
+        }
 
         switch (widget->windowFlags() & Qt::WindowType_Mask) {
         case Qt::Window:
@@ -8725,4 +8771,4 @@ QWidget *Style::getParent(const QWidget *widget, int level) const
         w = w->parentWidget();
     return w;
 }
-}
+} // namespace

--- a/kstyle/darklystyle.cpp
+++ b/kstyle/darklystyle.cpp
@@ -4001,7 +4001,7 @@ bool Style::drawFrameTabBarBasePrimitive(const QStyleOption *option, QPainter *p
     painter->setRenderHint(QPainter::Antialiasing, false);
 
     // precaution don't change the alpha channel if the tabbar opacity is at 100
-    if ((_isDolphin || _isKonsole) && StyleConfigData::tabBarOpacity() < 100) {
+    if ((_isDolphin || _isKonsole) && (StyleConfigData::tabBarOpacity() < 100)) {
         QColor backgroundColor = _helper->transparentBarBgColor(widget->palette().color(QPalette::Window), painter, widget->rect(), BarType::TabBar);
         painter->setBrush(backgroundColor);
         painter->fillRect(rect, backgroundColor);
@@ -4328,7 +4328,7 @@ bool Style::drawTabBarPanelButtonToolPrimitive(const QStyleOption *option, QPain
 
     if (_isDolphin || _isKonsole) {
         // change background color alpha channel
-        if (StyleConfigData::tabBarOpacity() < 100) {
+        if ((StyleConfigData::tabBarOpacity() < 100)) {
             // override the tab background color
             QColor tabBgColor = widget->palette().color(QPalette::Window);
             tabBgColor = _helper->transparentBarBgColor(tabBgColor, painter, rect, BarType::TabBar);
@@ -6760,7 +6760,9 @@ bool Style::drawTabBarTabShapeControl(const QStyleOption *option, QPainter *pain
         : _helper->alphaColor(configTabBgColor, 0.1);
 
     // opacity only target dolphin and konsole
-    if ((_isDolphin || _isKonsole) && StyleConfigData::tabBarOpacity() < 100) {
+    // if ((_isDolphin || _isKonsole) && (StyleConfigData::tabBarOpacity() < 100) && (widget->parentWidget()->inherits("DolphinTabWidget") ||
+    // widget->parentWidget()->inherits("Konsole::TabbedViewContainer"))) {
+    if ((_isDolphin || _isKonsole) && (StyleConfigData::tabBarOpacity() < 100)) {
         // override the tab background color if adjustToDarkThemes is false
         if (StyleConfigData::adjustToDarkThemes()) {
             backgroundColor = _helper->transparentBarBgColor(backgroundColor, painter, rect, BarType::TabBar);
@@ -8578,10 +8580,14 @@ void Style::setSurfaceFormat(QWidget *widget) const
     }
 
     else {
+        // this stops flickering on transparent toolbar, menubar, tabbar
+        if (_isBarsOpaque) {
+            widget->setAttribute(Qt::WA_TranslucentBackground);
+            widget->setAttribute(Qt::WA_NoSystemBackground, false);
+        }
+
         if (_isPlasma || _isOpaque || !widget->isWindow() || !_helper->shouldWindowHaveAlpha(widget->palette(), _isDolphin)) {
-            // continue if toolbar/menubar/tabbar are opaque
-            if (!_isBarsOpaque)
-                return;
+            return;
         }
 
         switch (widget->windowFlags() & Qt::WindowType_Mask) {
@@ -8633,9 +8639,6 @@ void Style::setSurfaceFormat(QWidget *widget) const
         return;
 
     widget->setAttribute(Qt::WA_TranslucentBackground);
-
-    // stop flickering on translucent background
-    widget->setAttribute(Qt::WA_NoSystemBackground, false);
 
     /* distinguish forced translucency from hard-coded translucency */
     // forcedTranslucency_.insert(widget);

--- a/kstyle/darklystyle.h
+++ b/kstyle/darklystyle.h
@@ -139,6 +139,7 @@ public:
 
     bool eventFilter(QObject *, QEvent *) override;
     bool eventFilterScrollArea(QWidget *, QEvent *);
+    bool eventFilterDolphinUrlNavigator(QWidget *, QEvent *);
     bool eventFilterComboBoxContainer(QWidget *, QEvent *);
     bool eventFilterDockWidget(QDockWidget *, QEvent *);
     bool eventFilterMdiSubWindow(QMdiSubWindow *, QEvent *);
@@ -606,6 +607,9 @@ private:
     bool _subApp = false;
     //* Some apps shouldn't have translucent windows.
     bool _isOpaque = false;
+
+    // blur is required for toolbar, menubar, tabbar if opaque
+    bool _isBarsOpaque = false;
 };
 
 //_________________________________________________________________________

--- a/kstyle/darklytoolsareamanager.h
+++ b/kstyle/darklytoolsareamanager.h
@@ -32,7 +32,11 @@ class ToolsAreaManager : public QObject
 
 private:
     Helper *_helper;
-    QHash<const QMainWindow *, QVector<QPointer<QToolBar>>> _windows;
+    struct WindowToolBars {
+        const QMainWindow *window;
+        QVector<QPointer<QToolBar>> toolBars;
+    };
+    std::vector<WindowToolBars> _windows;
     KSharedConfigPtr _config;
     KConfigWatcher::Ptr _watcher;
     QPalette _palette = QPalette();
@@ -40,12 +44,15 @@ private:
     bool _colorSchemeHasHeaderColor;
 
     void recreateConfigWatcher(const QString &path);
+    void appendIfNotAlreadyExists(const QMainWindow *window, const QPointer<QToolBar> &toolBar);
+    void removeWindowToolBar(const QMainWindow *window, const QPointer<QToolBar> &toolBar);
+    void removeWindow(const QMainWindow *window);
 
     friend class AppListener;
 
 protected:
-    bool tryRegisterToolBar(QPointer<QMainWindow> window, QPointer<QWidget> widget);
-    void tryUnregisterToolBar(QPointer<QMainWindow> window, QPointer<QWidget> widget);
+    bool tryRegisterToolBar(QPointer<const QMainWindow> window, QPointer<QWidget> widget);
+    void tryUnregisterToolBar(QPointer<const QMainWindow> window, QPointer<QWidget> widget);
     void configUpdated();
 
 public:
@@ -63,7 +70,7 @@ public:
     void registerWidget(QWidget *widget);
     void unregisterWidget(QWidget *widget);
 
-    QRect toolsAreaRect(const QMainWindow *window);
+    QRect toolsAreaRect(const QMainWindow &window) const;
 
     bool hasHeaderColors();
 };


### PR DESCRIPTION
This should resolve the following:

- #144 
- #114 
- #146  (animation still broken but it's not a big issue .. something which maybe can be fixed later on)
- #147  (only tabs inside Konsole and Dolphin are affected)

![opaque_tabs](https://github.com/user-attachments/assets/2dcbbe65-9dcf-4b53-bd59-31f223faa7b7)

New tabbar settings

![Screenshot_20250412_110923](https://github.com/user-attachments/assets/c52efa9c-f682-40d2-baf8-da9df31df18a)
