### PR TITLE
Re-enable Github workflow: Kubuntu 25.0.4

### DIFF
--- a/.github/assets/docker/kubuntu/Dockerfile
+++ b/.github/assets/docker/kubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.10
+FROM ubuntu:25.04
 MAINTAINER DeltaCopy
 USER root
 RUN apt-get update && \

--- a/.github/workflows/darkly-ci.yml
+++ b/.github/workflows/darkly-ci.yml
@@ -57,30 +57,30 @@ jobs:
       cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
       version: ${{ needs.release-ci.outputs.VERSION }}
 
-  # openSUSE-Tumbleweed:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/opensuse-tw.yml
-  #   with:
-  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  openSUSE-Tumbleweed:
+    needs: release-ci
+    uses: ./.github/workflows/opensuse-tw.yml
+    with:
+      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+      version: ${{ needs.release-ci.outputs.VERSION }}
 
-  # KDE-Neon:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/neon.yml
-  #   with:
-  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  KDE-Neon:
+    needs: release-ci
+    uses: ./.github/workflows/neon.yml
+    with:
+      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+      version: ${{ needs.release-ci.outputs.VERSION }}
 
-  # Fedora:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/fedora.yml
-  #   with:
-  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
-  #     containers: "['fedora:latest', 'fedora:40']"
+  Fedora:
+    needs: release-ci
+    uses: ./.github/workflows/fedora.yml
+    with:
+      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+      version: ${{ needs.release-ci.outputs.VERSION }}
+      containers: "['fedora:latest', 'fedora:40']"
 
-  # Archlinux:
-  #   needs: release-ci
-  #   uses: ./.github/workflows/archlinux.yml
-  #   with:
-  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  Archlinux:
+    needs: release-ci
+    uses: ./.github/workflows/archlinux.yml
+    with:
+      version: ${{ needs.release-ci.outputs.VERSION }}

--- a/.github/workflows/darkly-ci.yml
+++ b/.github/workflows/darkly-ci.yml
@@ -50,37 +50,37 @@ jobs:
           path: ${{ steps.step_get_asset.outputs.ASSET }}
           key: ${{ runner.os }}-v${{ steps.step_getlatest_tag.outputs.VERSION }}-${{ hashFiles(steps.step_get_asset.outputs.ASSET) }}
 
-  # Kubuntu:
+  Kubuntu:
+    needs: release-ci
+    uses: ./.github/workflows/kubuntu.yml
+    with:
+      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+      version: ${{ needs.release-ci.outputs.VERSION }}
+
+  # openSUSE-Tumbleweed:
   #   needs: release-ci
-  #   uses: ./.github/workflows/kubuntu.yml
+  #   uses: ./.github/workflows/opensuse-tw.yml
   #   with:
   #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
   #     version: ${{ needs.release-ci.outputs.VERSION }}
 
-  openSUSE-Tumbleweed:
-    needs: release-ci
-    uses: ./.github/workflows/opensuse-tw.yml
-    with:
-      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-      version: ${{ needs.release-ci.outputs.VERSION }}
+  # KDE-Neon:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/neon.yml
+  #   with:
+  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+  #     version: ${{ needs.release-ci.outputs.VERSION }}
 
-  KDE-Neon:
-    needs: release-ci
-    uses: ./.github/workflows/neon.yml
-    with:
-      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-      version: ${{ needs.release-ci.outputs.VERSION }}
+  # Fedora:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/fedora.yml
+  #   with:
+  #     cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
+  #     version: ${{ needs.release-ci.outputs.VERSION }}
+  #     containers: "['fedora:latest', 'fedora:40']"
 
-  Fedora:
-    needs: release-ci
-    uses: ./.github/workflows/fedora.yml
-    with:
-      cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
-      version: ${{ needs.release-ci.outputs.VERSION }}
-      containers: "['fedora:latest', 'fedora:40']"
-
-  Archlinux:
-    needs: release-ci
-    uses: ./.github/workflows/archlinux.yml
-    with:
-      version: ${{ needs.release-ci.outputs.VERSION }}
+  # Archlinux:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/archlinux.yml
+  #   with:
+  #     version: ${{ needs.release-ci.outputs.VERSION }}

--- a/.github/workflows/kubuntu.yml
+++ b/.github/workflows/kubuntu.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    container: deltacopy/kubuntu:0.1
+    container: deltacopy/kubuntu:0.2
     steps:
       - uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/kubuntu.yml
+++ b/.github/workflows/kubuntu.yml
@@ -24,7 +24,9 @@ jobs:
           fail-on-cache-miss: true
       - name: Install build dependencies
         run: |
-          apt-get install -y -qq cmake build-essential libkf5config-dev libkdecorations3-dev \
+          apt update -y
+          apt dist-upgrade -y
+          apt install -y -qq cmake build-essential libkf5config-dev libkdecorations3-dev \
                     libqt5x11extras5-dev qtdeclarative5-dev extra-cmake-modules \
                     libkf5guiaddons-dev libkf5configwidgets-dev libkf5windowsystem-dev kirigami2-dev \
                     libkf5coreaddons-dev libkf5iconthemes-dev gettext qt3d5-dev libkf5kcmutils-dev \


### PR DESCRIPTION
Kubuntu 25.04 is now on Plasma 6.3 so re-enabling.
https://kubuntu.org/news/kubuntu-25-04-plucky-puffin-released/

The docker container which the .deb file is built on has also been updated.