### PR TITLE
Reduce the widget frame width

### DIFF
--- a/kstyle/config/darklystyleconfig.cpp
+++ b/kstyle/config/darklystyleconfig.cpp
@@ -66,7 +66,7 @@ StyleConfig::StyleConfig(QWidget *parent)
     connect(_menuOpacity, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
     connect(_menuOpacity, SIGNAL(valueChanged(int)), _menuOpacitySpinBox, SLOT(setValue(int)));
     connect(_menuOpacitySpinBox, SIGNAL(valueChanged(int)), _menuOpacity, SLOT(setValue(int)));
-    connect(_buttonSize, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
+
     connect(_sidebarOpacity, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
     connect(_sidebarOpacity, SIGNAL(valueChanged(int)), _sidebarOpacitySpinBox, SLOT(setValue(int)));
     connect(_sidebarOpacitySpinBox, SIGNAL(valueChanged(int)), _sidebarOpacity, SLOT(setValue(int)));
@@ -105,6 +105,9 @@ StyleConfig::StyleConfig(QWidget *parent)
     connect(_tabUseBrighterCloseIcon, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
     connect(_disableDolphinUrlNavigatorBackground, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
     connect(_tabsHeight, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
+
+    connect(_buttonHeight, SIGNAL(valueChanged(int)), SLOT(updateChanged()));
+    connect(_buttonWidth, SIGNAL(valueChanged(int)), SLOT(updateChanged()));
 }
 
 //__________________________________________________________________
@@ -132,7 +135,6 @@ void StyleConfig::save()
     StyleConfigData::setMenuBarOpacity(_menuBarOpacity->value());
     StyleConfigData::setToolBarOpacity(_toolBarOpacity->value());
     StyleConfigData::setTabBarOpacity(_tabBarOpacity->value());
-    StyleConfigData::setButtonSize(_buttonSize->value());
     StyleConfigData::setKTextEditDrawFrame(_kTextEditDrawFrame->isChecked());
     StyleConfigData::setWidgetDrawShadow(_widgetDrawShadow->isChecked());
     StyleConfigData::setWidgetToolBarShadow(_widgetToolBarShadow->isChecked());
@@ -151,6 +153,8 @@ void StyleConfig::save()
     StyleConfigData::setTabUseBrighterCloseIcon(_tabUseBrighterCloseIcon->isChecked());
     StyleConfigData::setDisableDolphinUrlNavigatorBackground(_disableDolphinUrlNavigatorBackground->isChecked());
     StyleConfigData::setTabsHeight(_tabsHeight->value());
+    StyleConfigData::setButtonHeight(_buttonHeight->value());
+    StyleConfigData::setButtonWidth(_buttonWidth->value());
 
     StyleConfigData::self()->save();
 
@@ -217,9 +221,11 @@ void StyleConfig::updateChanged()
     else if (_menuOpacity->value() != StyleConfigData::menuOpacity()) {
         modified = true;
         _menuOpacitySpinBox->setValue(_menuOpacity->value());
-    } else if (_buttonSize->value() != StyleConfigData::buttonSize())
+    } else if (_buttonHeight->value() != StyleConfigData::buttonHeight()) {
         modified = true;
-    else if (_sidebarOpacity->value() != StyleConfigData::dolphinSidebarOpacity()) {
+    } else if (_buttonWidth->value() != StyleConfigData::buttonWidth()) {
+        modified = true;
+    } else if (_sidebarOpacity->value() != StyleConfigData::dolphinSidebarOpacity()) {
         modified = true;
         _sidebarOpacitySpinBox->setValue(_sidebarOpacity->value());
     } else if (_menuBarOpacity->value() != StyleConfigData::menuBarOpacity()) {
@@ -325,8 +331,8 @@ void StyleConfig::load()
     _toolBarOpacitySpinBox->setValue(StyleConfigData::toolBarOpacity());
     _tabBarOpacity->setValue(StyleConfigData::tabBarOpacity());
     _tabBarOpacitySpinBox->setValue(StyleConfigData::tabBarOpacity());
-
-    _buttonSize->setValue(StyleConfigData::buttonSize());
+    _buttonHeight->setValue(StyleConfigData::buttonHeight());
+    _buttonWidth->setValue(StyleConfigData::buttonWidth());
     _kTextEditDrawFrame->setChecked(StyleConfigData::kTextEditDrawFrame());
     _widgetDrawShadow->setChecked(StyleConfigData::widgetDrawShadow());
     _widgetToolBarShadow->setChecked(StyleConfigData::widgetToolBarShadow());

--- a/kstyle/config/ui/darklystyleconfig.ui
+++ b/kstyle/config/ui/darklystyleconfig.ui
@@ -75,123 +75,7 @@
        <property name="spacing">
         <number>13</number>
        </property>
-       <item row="52" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_18">
-         <item>
-          <widget class="QLabel" name="_mnemonicsLabel">
-           <property name="text">
-            <string>Keyboard accelerators visibility:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-           <property name="indent">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="_mnemonicsMode">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="layoutDirection">
-            <enum>Qt::LayoutDirection::LeftToRight</enum>
-           </property>
-           <item>
-            <property name="text">
-             <string>Always Hide</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>When Needed</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Always Show</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_12">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item row="51" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_17">
-         <item>
-          <widget class="QLabel" name="label_12">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Corner Radius:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-           <property name="indent">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="_cornerRadius">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="suffix">
-            <string> px</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>8</number>
-           </property>
-           <property name="value">
-            <number>6</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_9">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item row="53" column="0">
+       <item row="47" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_19">
          <item>
           <widget class="QLabel" name="_windowDragLabel">
@@ -258,107 +142,144 @@
          </item>
         </layout>
        </item>
-       <item row="3" column="0" rowspan="2" colspan="3">
-        <layout class="QGridLayout" name="gridLayout_4">
-         <property name="sizeConstraint">
-          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+       <item row="2" column="0" colspan="2">
+        <widget class="QCheckBox" name="_viewDrawFocusIndicator">
+         <property name="text">
+          <string>Draw focus indicator in lists</string>
          </property>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_2">
+        </widget>
+       </item>
+       <item row="46" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_18">
+         <item>
+          <widget class="QLabel" name="_mnemonicsLabel">
+           <property name="text">
+            <string>Keyboard accelerators visibility:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="_mnemonicsMode">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LayoutDirection::LeftToRight</enum>
+           </property>
+           <item>
+            <property name="text">
+             <string>Always Hide</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>When Needed</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Always Show</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_12">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QCheckBox" name="_toolBarDrawItemSeparator">
+         <property name="text">
+          <string>Draw toolbar item separators</string>
+         </property>
+        </widget>
+       </item>
+       <item row="45" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
+         <item>
+          <widget class="QLabel" name="label_12">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Button Size:</string>
+            <string>Corner Radius:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
           </widget>
          </item>
-         <item row="2" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_16">
-           <property name="sizeConstraint">
-            <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_4">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Smaller</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Bigger</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSlider" name="_buttonSize">
+         <item>
+          <widget class="QSpinBox" name="_cornerRadius">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="suffix">
+            <string> px</string>
+           </property>
            <property name="minimum">
-            <number>-2</number>
-           </property>
-           <property name="maximum">
-            <number>6</number>
-           </property>
-           <property name="singleStep">
             <number>1</number>
            </property>
-           <property name="sliderPosition">
-            <number>4</number>
+           <property name="maximum">
+            <number>8</number>
            </property>
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="tickPosition">
-            <enum>QSlider::TickPosition::TicksBelow</enum>
-           </property>
-           <property name="tickInterval">
-            <number>2</number>
+           <property name="value">
+            <number>6</number>
            </property>
           </widget>
          </item>
+         <item>
+          <spacer name="horizontalSpacer_9">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </item>
-       <item row="54" column="2">
+       <item row="0" column="0" colspan="2">
+        <widget class="QCheckBox" name="_scrollableMenu">
+         <property name="text">
+          <string>Scrollable popup menu</string>
+         </property>
+        </widget>
+       </item>
+       <item row="48" column="1">
         <widget class="QLabel" name="_versionNumber">
          <property name="font">
           <font>
@@ -376,25 +297,97 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0" colspan="3">
-        <widget class="QCheckBox" name="_viewDrawFocusIndicator">
-         <property name="text">
-          <string>Draw focus indicator in lists</string>
+       <item row="3" column="0" rowspan="2" colspan="2">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Increase button size</string>
          </property>
-        </widget>
-       </item>
-       <item row="0" column="0" colspan="3">
-        <widget class="QCheckBox" name="_scrollableMenu">
-         <property name="text">
-          <string>Scrollable popup menu</string>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="3">
-        <widget class="QCheckBox" name="_toolBarDrawItemSeparator">
-         <property name="text">
-          <string>Draw toolbar item separators</string>
+         <property name="flat">
+          <bool>false</bool>
          </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <widget class="QWidget" name="layoutWidget">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>30</y>
+            <width>621</width>
+            <height>42</height>
+           </rect>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_16">
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Height:</string>
+             </property>
+             <property name="indent">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="_buttonHeight">
+             <property name="suffix">
+              <string> px</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Width:</string>
+             </property>
+             <property name="indent">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="_buttonWidth">
+             <property name="suffix">
+              <string> px</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
@@ -1425,100 +1418,99 @@
         <string>Draw widget shadow</string>
        </property>
       </widget>
-      <widget class="QFrame" name="frame">
+      <widget class="QCheckBox" name="_widgetToolBarShadow">
        <property name="geometry">
         <rect>
-         <x>10</x>
-         <y>70</y>
-         <width>611</width>
-         <height>231</height>
+         <x>20</x>
+         <y>40</y>
+         <width>211</width>
+         <height>24</height>
         </rect>
        </property>
-       <property name="frameShape">
-        <enum>QFrame::Shape::NoFrame</enum>
+       <property name="text">
+        <string>Draw shadow under toolbar</string>
        </property>
-       <property name="frameShadow">
-        <enum>QFrame::Shadow::Plain</enum>
+      </widget>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>70</y>
+         <width>631</width>
+         <height>311</height>
+        </rect>
        </property>
-       <widget class="QLabel" name="label_16">
+       <property name="title">
+        <string>These settings change how menu shadow outlines are displayed</string>
+       </property>
+       <widget class="QWidget" name="">
         <property name="geometry">
          <rect>
-          <x>50</x>
-          <y>4</y>
-          <width>541</width>
-          <height>20</height>
+          <x>10</x>
+          <y>30</y>
+          <width>611</width>
+          <height>43</height>
          </rect>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::Shape::NoFrame</enum>
-        </property>
-        <property name="text">
-         <string>These settings change how menu shadow outlines are displayed</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignmentFlag::AlignCenter</set>
-        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_21">
+         <item>
+          <widget class="QLabel" name="label_13">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Size:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="_shadowSize">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="currentIndex">
+            <number>-1</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
        </widget>
        <widget class="QWidget" name="gridLayoutWidget">
         <property name="geometry">
          <rect>
           <x>10</x>
-          <y>30</y>
-          <width>591</width>
+          <y>80</y>
+          <width>611</width>
           <height>198</height>
          </rect>
         </property>
         <layout class="QGridLayout" name="gridLayout_3">
-         <item row="0" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_21">
-           <item>
-            <widget class="QLabel" name="label_13">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Size:      </string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-             </property>
-             <property name="indent">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="_shadowSize">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="currentIndex">
-              <number>-1</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_5">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="2" column="0">
+         <item row="1" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_13">
            <item>
             <widget class="QLabel" name="label_17">
@@ -1532,10 +1524,10 @@
               <string>Intensity:</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
              <property name="indent">
-              <number>0</number>
+              <number>5</number>
              </property>
             </widget>
            </item>
@@ -1587,53 +1579,7 @@
            </item>
           </layout>
          </item>
-         <item row="1" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_14">
-           <item>
-            <widget class="QLabel" name="label_14">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Color:     </string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignCenter</set>
-             </property>
-             <property name="indent">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="KColorCombo" name="_shadowColor">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_6">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="3" column="0">
+         <item row="2" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_20">
            <item>
             <widget class="QLabel" name="label_15">
@@ -1650,7 +1596,7 @@
               <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
              <property name="indent">
-              <number>0</number>
+              <number>5</number>
              </property>
             </widget>
            </item>
@@ -1688,21 +1634,54 @@
            </item>
           </layout>
          </item>
+         <item row="0" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_14">
+           <item>
+            <widget class="QLabel" name="label_14">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Color:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+             <property name="indent">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="KColorCombo" name="_shadowColor">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_6">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
         </layout>
        </widget>
-      </widget>
-      <widget class="QCheckBox" name="_widgetToolBarShadow">
-       <property name="geometry">
-        <rect>
-         <x>20</x>
-         <y>40</y>
-         <width>211</width>
-         <height>24</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Draw shadow under toolbar</string>
-       </property>
       </widget>
      </widget>
     </widget>

--- a/kstyle/darkly.h
+++ b/kstyle/darkly.h
@@ -44,7 +44,7 @@ using ScopedPointer = QScopedPointer<T, QScopedPointerPodDeleter>;
 //* metrics
 enum Metrics {
     // frames
-    Frame_FrameWidth = 5,
+    Frame_FrameWidth = 2,
     // Frame_FrameRadius = 6,
 
     // layout

--- a/kstyle/darkly.kcfg
+++ b/kstyle/darkly.kcfg
@@ -1,63 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kcfg xmlns="http://www.kde.org/standards/kcfg/1.0"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
 
-  <kcfgfile name="darklyrc"/>
+  <kcfgfile name="darklyrc" />
 
   <!-- common options -->
   <group name="Common">
 
     <!-- shadow strength-->
-    <entry name="ShadowStrength" type = "Int">
-       <default>255</default>
-       <min>25</min>
-       <max>255</max>
+    <entry name="ShadowStrength" type="Int">
+      <default>255</default>
+      <min>25</min>
+      <max>255</max>
     </entry>
 
     <!-- shadow size -->
-    <entry name="ShadowSize" type = "Enum">
+    <entry name="ShadowSize" type="Enum">
       <choices>
-          <choice name="ShadowNone"/>
-          <choice name="ShadowSmall"/>
-          <choice name="ShadowMedium"/>
-          <choice name="ShadowLarge"/>
-          <choice name="ShadowVeryLarge"/>
+        <choice name="ShadowNone" />
+        <choice name="ShadowSmall" />
+        <choice name="ShadowMedium" />
+        <choice name="ShadowLarge" />
+        <choice name="ShadowVeryLarge" />
       </choices>
       <default>ShadowLarge</default>
     </entry>
 
     <!-- shadow color -->
-    <entry name="ShadowColor" type = "Color">
-       <default>0, 0, 0</default>
+    <entry name="ShadowColor" type="Color">
+      <default>0, 0, 0</default>
     </entry>
 
     <!-- shadow intensity -->
-     <entry name="ShadowIntensity" type = "Enum">
-       <choices>
-          <choice name="Low"/>
-          <choice name="Medium"/>
-          <choice name="High"/>
-          <choice name="Maximum"/>
+    <entry name="ShadowIntensity" type="Enum">
+      <choices>
+        <choice name="Low" />
+        <choice name="Medium" />
+        <choice name="High" />
+        <choice name="Maximum" />
       </choices>
       <default>Medium</default>
     </entry>
 
     <!-- close button -->
-    <entry name="OutlineCloseButton" type = "Bool">
-        <default>false</default>
+    <entry name="OutlineCloseButton" type="Bool">
+      <default>false</default>
     </entry>
-    
+
     <!-- corner radius -->
-    <entry name="CornerRadius" type = "Int">
-       <default>6</default>
-       <min>1</min>
-       <max>8</max>
+    <entry name="CornerRadius" type="Int">
+      <default>6</default>
+      <min>1</min>
+      <max>8</max>
     </entry>
 
     <!-- button size -->
-    <entry name="ButtonSize" type="Int">
-        <default>4</default>
+    <entry name="ButtonHeight" type="Int">
+      <default>3</default>
+    </entry>
+
+    <entry name="ButtonWidth" type="Int">
+      <default>3</default>
     </entry>
   </group>
 
@@ -69,15 +73,15 @@
       <default>true</default>
     </entry>
 
-    <entry name="AnimationSteps" type = "Int">
-       <default>30</default>
+    <entry name="AnimationSteps" type="Int">
+      <default>30</default>
     </entry>
 
     <entry name="AnimationsDuration" type="Int">
       <default>250</default>
     </entry>
 
-   <!-- transition flags -->
+    <!-- transition flags -->
     <entry name="StackedWidgetTransitionsEnabled" type="Bool">
       <default>false</default>
     </entry>
@@ -104,9 +108,9 @@
     <!-- mnemonics -->
     <entry name="MnemonicsMode" type="Enum">
       <choices>
-          <choice name="MN_NEVER" />
-          <choice name="MN_AUTO" />
-          <choice name="MN_ALWAYS" />
+        <choice name="MN_NEVER" />
+        <choice name="MN_AUTO" />
+        <choice name="MN_ALWAYS" />
       </choices>
       <default>MN_AUTO</default>
     </entry>
@@ -115,7 +119,7 @@
     <entry name="ToolBarDrawItemSeparator" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <entry name="ToolBarDrawSeparator" type="Bool">
       <default>false</default>
     </entry>
@@ -124,11 +128,11 @@
     <entry name="ViewDrawFocusIndicator" type="Bool">
       <default>true</default>
     </entry>
-    
+
     <entry name="TransparentDolphinView" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <!-- shadows on widgets -->
     <entry name="WidgetDrawShadow" type="Bool">
       <default>true</default>
@@ -142,7 +146,7 @@
     <entry name="ScrollableMenu" type="Bool">
       <default>true</default>
     </entry>
-    
+
     <entry name="OldTabbar" type="Bool">
       <default>false</default>
     </entry>
@@ -160,19 +164,19 @@
     <entry name="TabBarAltStyle" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <entry name="TabBarDrawCenteredTabs" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <entry name="TabBarTabExpandFullWidth" type="Bool">
       <default>true</default>
     </entry>
-    
+
     <entry name="TabDrawHighlight" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <entry name="UnifiedTabBarKonsole" type="Bool">
       <default>false</default>
     </entry>
@@ -189,7 +193,7 @@
       <default>true</default>
     </entry>
 
-     <entry name="TabUseBrighterCloseIcon" type="Bool">
+    <entry name="TabUseBrighterCloseIcon" type="Bool">
       <default>false</default>
     </entry>
 
@@ -205,7 +209,7 @@
     <entry name="DockWidgetDrawFrame" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <entry name="KTextEditDrawFrame" type="Bool">
       <default>false</default>
     </entry>
@@ -225,9 +229,9 @@
     <!-- window dragging -->
     <entry name="WindowDragMode" type="Enum">
       <choices>
-          <choice name="WD_NONE" />
-          <choice name="WD_MINIMAL" />
-          <choice name="WD_FULL" />
+        <choice name="WD_NONE" />
+        <choice name="WD_MINIMAL" />
+        <choice name="WD_FULL" />
       </choices>
       <default>WD_FULL</default>
     </entry>
@@ -238,7 +242,7 @@
         standard widgets. They are reference by the widget class name.
     -->
     <entry name="WindowDragWhiteList" type="StringList">
-       <default></default>
+      <default></default>
     </entry>
 
     <!--
@@ -247,19 +251,19 @@
         standard widgets). They are reference by the widget class name.
     -->
     <entry name="WindowDragBlackList" type="StringList">
-       <default></default>
+      <default></default>
     </entry>
-    
+
     <!-- 
         this is the comma separated list of special apps that should have no
         transparency.
     -->
     <entry name="OpaqueApps" type="StringList">
-       <default></default>
+      <default></default>
     </entry>
-    
+
     <entry name="ForceOpaque" type="StringList">
-       <default>kscreenlocker,wine,vlc,kdevelop,smplayer,virtualbox,virtualboxvm,obs,kaffeine,kstars,digikam,kdenlive</default>
+      <default>kscreenlocker,wine,vlc,kdevelop,smplayer,virtualbox,virtualboxvm,obs,kaffeine,kstars,digikam,kdenlive</default>
     </entry>
 
     <!-- if true, move events are passed to the window manager (e.g. KWin) -->
@@ -287,11 +291,11 @@
 
     <!-- transparency -->
     <entry name="MenuOpacity" type="Int">
-        <default>100</default>
+      <default>100</default>
     </entry>
-    
+
     <entry name="DolphinSidebarOpacity" type="Int">
-        <default>100</default>
+      <default>100</default>
     </entry>
 
     <entry name="MenuBarOpacity" type="Int">
@@ -299,17 +303,17 @@
     </entry>
 
     <entry name="ToolBarOpacity" type="Int">
-        <default>100</default>
+      <default>100</default>
     </entry>
 
-     <entry name="TabBarOpacity" type="Int">
-        <default>100</default>
+    <entry name="TabBarOpacity" type="Int">
+      <default>100</default>
     </entry>
 
     <entry name="AdjustToDarkThemes" type="Bool">
       <default>false</default>
     </entry>
-    <entry name="TabBGColor" type = "Color">
+    <entry name="TabBGColor" type="Color">
       <default>0, 0, 0</default>
     </entry>
   </group>

--- a/kstyle/darklyhelper.cpp
+++ b/kstyle/darklyhelper.cpp
@@ -686,13 +686,9 @@ void Helper::renderButtonFrame(QPainter *painter,
 
     painter->setPen(Qt::NoPen);
 
-    // copy rect
-    QRectF frameRect(rect);
-
     // reduce the size of the actual button, the rest will be the shadow
-    frameRect.adjust(5, 5, -5, -5);
-
-    qreal radius(frameRadius() - 1);
+    QRectF frameRect(rect.adjusted(Metrics::Frame_FrameWidth, Metrics::Frame_FrameWidth, -Metrics::Frame_FrameWidth, -Metrics::Frame_FrameWidth));
+    qreal radius(frameRadius() - qreal(Metrics::Frame_FrameWidth));
 
     if (sunken) {
         frameRect.translate(0, 1);
@@ -1717,7 +1713,7 @@ bool Helper::isWayland()
 }
 
 //______________________________________________________________________________
-QRectF Helper::strokedRect(const QRectF &rect, const int penWidth) const
+QRectF Helper::strokedRect(const QRectF &rect, const qreal penWidth) const
 {
     /* With a pen stroke width of 1, the rectangle should have each of its
      * sides moved inwards by half a pixel. This allows the stroke to be
@@ -1727,11 +1723,6 @@ QRectF Helper::strokedRect(const QRectF &rect, const int penWidth) const
      */
     qreal adjustment = 0.5 * penWidth;
     return QRectF(rect).adjusted(adjustment, adjustment, -adjustment, -adjustment);
-}
-
-QRectF Helper::strokedRect(const QRect &rect, const int penWidth) const
-{
-    return strokedRect(QRectF(rect), penWidth);
 }
 
 //______________________________________________________________________________

--- a/kstyle/darklyhelper.h
+++ b/kstyle/darklyhelper.h
@@ -420,10 +420,13 @@ public:
     }
 
     //* return a QRectF with the appropriate size for a rectangle with a pen stroke
-    QRectF strokedRect(const QRectF &rect, const int penWidth = PenWidth::Frame) const;
+    QRectF strokedRect(const QRectF &rect, const qreal penWidth = PenWidth::Frame) const;
 
-    //* return a QRectF with the appropriate size for a rectangle with a pen stroke
-    QRectF strokedRect(const QRect &rect, const int penWidth = PenWidth::Frame) const;
+    //* return a QRectF with the appropriate size for a rectangle with a shadow around it
+    QRectF shadowedRect(const QRectF &rect, const qreal shadowSize = PenWidth::Shadow) const
+    {
+        return rect.adjusted(shadowSize, shadowSize, -shadowSize, -shadowSize);
+    }
 
     QPixmap coloredIcon(const QIcon &icon,
                         const QPalette &palette,

--- a/kstyle/darklystyle.cpp
+++ b/kstyle/darklystyle.cpp
@@ -3286,7 +3286,7 @@ QSize Style::comboBoxSizeFromContents(const QStyleOption *option, const QSize &c
         size = expandSize(size, frameWidth);
 
     // make sure there is enough height for the button
-    size.setHeight(qMax(size.height() + StyleConfigData::buttonSize(), int(Metrics::MenuButton_IndicatorWidth)));
+    size.setHeight(qMax(size.height() + Metrics::Frame_FrameWidth, int(Metrics::MenuButton_IndicatorWidth)));
 
     // add button width and spacing
     size.rwidth() += Metrics::MenuButton_IndicatorWidth + 2;
@@ -3314,7 +3314,7 @@ QSize Style::spinBoxSizeFromContents(const QStyleOption *option, const QSize &co
         size = expandSize(size, frameWidth);
 
     // make sure there is enough height for the button
-    size.setHeight(qMax(size.height() + StyleConfigData::buttonSize(), int(Metrics::SpinBox_ArrowButtonWidth)));
+    size.setHeight(qMax(size.height() + Metrics::Frame_FrameWidth, int(Metrics::SpinBox_ArrowButtonWidth)));
 
     // add button width and spacing
     size.rwidth() += Metrics::SpinBox_ArrowButtonWidth;
@@ -3407,7 +3407,7 @@ QSize Style::pushButtonSizeFromContents(const QStyleOption *option, const QSize 
             if (!iconSize.isValid())
                 iconSize = QSize(pixelMetric(PM_SmallIconSize, option, widget), pixelMetric(PM_SmallIconSize, option, widget));
 
-            size.setHeight(qMax(size.height() + StyleConfigData::buttonSize(), iconSize.height()));
+            size.setHeight(qMax(size.height(), iconSize.height()));
             size.rwidth() += iconSize.width();
 
             if (hasText)
@@ -3430,6 +3430,11 @@ QSize Style::pushButtonSizeFromContents(const QStyleOption *option, const QSize 
     if (hasText) {
         size.setWidth(qMax(size.width(), int(Metrics::Button_MinWidth)));
     }
+
+    // adjust the size add on the button size from StyleConfigData
+
+    size.rwidth() += StyleConfigData::buttonWidth();
+    size.rheight() += StyleConfigData::buttonHeight();
 
     // finally add frame margins
     return expandSize(size, Metrics::Frame_FrameWidth);


### PR DESCRIPTION
#170 

Changes.

- Set the value for Frame_FrameWidth from 5 to 2 which matches Breeze

- Added a setting to change the width & height of a button (by default this is set to 3 for each)

- The resizing of a button also now uses the Frame_FrameWidth when it comes to drawing the shadow
