### PR TITLE
GitHub Actions update Fedora

### DIFF
--- a/.github/workflows/darkly-ci.yml
+++ b/.github/workflows/darkly-ci.yml
@@ -77,7 +77,7 @@ jobs:
     with:
       cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
       version: ${{ needs.release-ci.outputs.VERSION }}
-      containers: "['fedora:latest', 'fedora:40']"
+      containers: "['fedora:latest', 'fedora:41', 'fedora:40']"
 
   Archlinux:
     needs: release-ci


### PR DESCRIPTION
Build RPMs for Fedora 40, Fedora 41 and Fedora 42 (latest)