### PR TITLE
Blur: only change it for the tabs inside konsole & dolphin setting/about dialogs

### DIFF
--- a/kstyle/darklyblurhelper.cpp
+++ b/kstyle/darklyblurhelper.cpp
@@ -340,8 +340,9 @@ QRegion BlurHelper::blurSettingsDialogRegion(QWidget *widget) const
     QRegion region;
     QList<QWidget *> widgets = widget->findChildren<QWidget *>();
 
-    // settings
-    if ((widget->windowFlags() & Qt::WindowType_Mask) == Qt::Dialog) {
+    // settings only change it for konsole or dolphin about window
+    if ((widget->windowFlags() & Qt::WindowType_Mask) == Qt::Dialog
+        && (widget->inherits("KAboutApplicationDialog") || widget->inherits("KDEPrivate::KAboutKdeDialog"))) {
         for (auto w : widgets) {
             if (qobject_cast<QTabWidget *>(w) && (widget->inherits("KAboutApplicationDialog") || widget->inherits("KDEPrivate::KAboutKdeDialog"))) {
                 // about dialog


### PR DESCRIPTION
Seeing a performance hit on some apps when opening the settings window.
qBitorrent for example was considerably lagging when switching through the tabs inside the settings.