### PR TITLE
Flatpak support for Darkly

### DIFF
--- a/.github/workflows/darkly-ci.yml
+++ b/.github/workflows/darkly-ci.yml
@@ -77,7 +77,7 @@ jobs:
     with:
       cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
       version: ${{ needs.release-ci.outputs.VERSION }}
-      containers: "['fedora:latest', 'fedora:40']"
+      containers: "['fedora:latest', 'fedora:41', 'fedora:40']"
 
   Archlinux:
     needs: release-ci

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,13 +37,14 @@ include(KDEGitCommitHooks)
 
 include(GtkUpdateIconCache)
 
+option(FOR_FLATPAK "Build Lightly for Flatpak" OFF)
 option(BUILD_QT5 "Build with QT5" ON)
 option(BUILD_QT6 "Build with QT6" ON)
 
 set(QT_NO_CREATE_VERSIONLESS_TARGETS ON)
 set(QT_NO_CREATE_VERSIONLESS_FUNCTIONS ON)
 
-if(WIN32 OR APPLE)
+if(WIN32 OR APPLE OR FOR_FLATPAK)
     set(WITH_DECORATIONS OFF)
 endif()
 
@@ -61,22 +62,22 @@ function(build_qt5)
             I18n
             IconThemes
             WindowSystem)
-        if(NOT WIN32 AND NOT APPLE)
-            find_package(KF5KCMUtils ${KF5_MIN_VERSION})
-            set_package_properties(KF5KCMUtils PROPERTIES
+    if(NOT WIN32 AND NOT APPLE)
+        find_package(KF5KCMUtils ${KF5_MIN_VERSION})
+        set_package_properties(KF5KCMUtils PROPERTIES
                 TYPE REQUIRED
                 DESCRIPTION "Helps create configuration modules"
                 PURPOSE "KCMUtils used for the configuration modules or the decoration and Qt Style"
             )
-        endif()
+    endif()
 
     find_package(Qt5 ${QT5_MIN_VERSION} OPTIONAL_COMPONENTS Quick)
-        if(${Qt5Quick_FOUND})
+    if(${Qt5Quick_FOUND})
         find_package(KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS Kirigami2)
-        endif()
+    endif()
 
     find_package(KF5FrameworkIntegration ${KF5_MIN_VERSION} CONFIG )
-        set_package_properties(KF${QT_MAJOR_VERSION}FrameworkIntegration PROPERTIES
+    set_package_properties(KF${QT_MAJOR_VERSION}FrameworkIntegration PROPERTIES
             DESCRIPTION "KF${QT_MAJOR_VERSION} Framework Integration"
             URL "https://projects.kde.org/projects/frameworks/frameworkintegration"
             TYPE OPTIONAL
@@ -113,22 +114,22 @@ function(build_qt6)
             I18n
             IconThemes
             WindowSystem)
-        if(NOT WIN32 AND NOT APPLE)
-            find_package(KF6KCMUtils ${KF6_MIN_VERSION})
-            set_package_properties(KF6KCMUtils PROPERTIES
+    if(NOT WIN32 AND NOT APPLE)
+        find_package(KF6KCMUtils ${KF6_MIN_VERSION})
+        set_package_properties(KF6KCMUtils PROPERTIES
                 TYPE REQUIRED
                 DESCRIPTION "Helps create configuration modules"
                 PURPOSE "KCMUtils used for the configuration modules or the decoration and Qt Style"
             )
-        endif()
+    endif()
 
     find_package(Qt6 ${QT_MIN_VERSION} OPTIONAL_COMPONENTS Quick)
-        if(${Qt6Quick_FOUND})
-            find_package(KF6KirigamiPlatform ${KF6_MIN_VERSION} REQUIRED)
-        endif()
+    if(${Qt6Quick_FOUND})
+        find_package(KF6KirigamiPlatform ${KF6_MIN_VERSION} REQUIRED)
+    endif()
 
     find_package(KF6FrameworkIntegration ${KF6_MIN_VERSION} CONFIG )
-        set_package_properties(KF${QT_MAJOR_VERSION}FrameworkIntegration PROPERTIES
+    set_package_properties(KF${QT_MAJOR_VERSION}FrameworkIntegration PROPERTIES
             DESCRIPTION "KF${QT_MAJOR_VERSION} Framework Integration"
             URL "https://projects.kde.org/projects/frameworks/frameworkintegration"
             TYPE OPTIONAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,17 +170,19 @@ function(build_qt6)
 
     set(CMAKECONFIG_INSTALL_DIR "${KDE_INSTALL_CMAKEPACKAGEDIR}/Darkly")
 
-    configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/DarklyConfig.cmake.in"
-                                    "${CMAKE_CURRENT_BINARY_DIR}/DarklyConfig.cmake"
-                                    PATH_VARS KDE_INSTALL_FULL_DATADIR
-                                    INSTALL_DESTINATION  ${CMAKECONFIG_INSTALL_DIR}
-                                )
+    if (!FOR_FLATPAK)
+        configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/DarklyConfig.cmake.in"
+                                        "${CMAKE_CURRENT_BINARY_DIR}/DarklyConfig.cmake"
+                                        PATH_VARS KDE_INSTALL_FULL_DATADIR
+                                        INSTALL_DESTINATION  ${CMAKECONFIG_INSTALL_DIR}
+                                    )
 
-    install(FILES  "${CMAKE_CURRENT_BINARY_DIR}/DarklyConfig.cmake"
-                    "${CMAKE_CURRENT_BINARY_DIR}/DarklyConfigVersion.cmake"
-                DESTINATION "${CMAKECONFIG_INSTALL_DIR}"
-                COMPONENT Devel
-            )
+        install(FILES  "${CMAKE_CURRENT_BINARY_DIR}/DarklyConfig.cmake"
+                        "${CMAKE_CURRENT_BINARY_DIR}/DarklyConfigVersion.cmake"
+                    DESTINATION "${CMAKECONFIG_INSTALL_DIR}"
+                    COMPONENT Devel
+                )
+    endif()
     unset(QUERY_EXECUTABLE CACHE)
 endfunction()
 
@@ -194,7 +196,9 @@ function(build_colors)
     add_subdirectory(colors)
 endfunction()
 
-build_colors()
+if (!FOR_FLATPAK)
+    build_colors()
+endif()
 
 # add clang-format target for all our real source files
 file(GLOB_RECURSE ALL_CLANG_FORMAT_SOURCE_FILES *.cpp *.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,22 +62,22 @@ function(build_qt5)
             I18n
             IconThemes
             WindowSystem)
-    if(NOT WIN32 AND NOT APPLE)
-        find_package(KF5KCMUtils ${KF5_MIN_VERSION})
-        set_package_properties(KF5KCMUtils PROPERTIES
+        if(NOT WIN32 AND NOT APPLE)
+            find_package(KF5KCMUtils ${KF5_MIN_VERSION})
+            set_package_properties(KF5KCMUtils PROPERTIES
                 TYPE REQUIRED
                 DESCRIPTION "Helps create configuration modules"
                 PURPOSE "KCMUtils used for the configuration modules or the decoration and Qt Style"
             )
-    endif()
+        endif()
 
     find_package(Qt5 ${QT5_MIN_VERSION} OPTIONAL_COMPONENTS Quick)
-    if(${Qt5Quick_FOUND})
+        if(${Qt5Quick_FOUND})
         find_package(KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS Kirigami2)
-    endif()
+        endif()
 
     find_package(KF5FrameworkIntegration ${KF5_MIN_VERSION} CONFIG )
-    set_package_properties(KF${QT_MAJOR_VERSION}FrameworkIntegration PROPERTIES
+        set_package_properties(KF${QT_MAJOR_VERSION}FrameworkIntegration PROPERTIES
             DESCRIPTION "KF${QT_MAJOR_VERSION} Framework Integration"
             URL "https://projects.kde.org/projects/frameworks/frameworkintegration"
             TYPE OPTIONAL
@@ -114,22 +114,22 @@ function(build_qt6)
             I18n
             IconThemes
             WindowSystem)
-    if(NOT WIN32 AND NOT APPLE)
-        find_package(KF6KCMUtils ${KF6_MIN_VERSION})
-        set_package_properties(KF6KCMUtils PROPERTIES
+        if(NOT WIN32 AND NOT APPLE)
+            find_package(KF6KCMUtils ${KF6_MIN_VERSION})
+            set_package_properties(KF6KCMUtils PROPERTIES
                 TYPE REQUIRED
                 DESCRIPTION "Helps create configuration modules"
                 PURPOSE "KCMUtils used for the configuration modules or the decoration and Qt Style"
             )
-    endif()
+        endif()
 
     find_package(Qt6 ${QT_MIN_VERSION} OPTIONAL_COMPONENTS Quick)
-    if(${Qt6Quick_FOUND})
-        find_package(KF6KirigamiPlatform ${KF6_MIN_VERSION} REQUIRED)
-    endif()
+        if(${Qt6Quick_FOUND})
+            find_package(KF6KirigamiPlatform ${KF6_MIN_VERSION} REQUIRED)
+        endif()
 
     find_package(KF6FrameworkIntegration ${KF6_MIN_VERSION} CONFIG )
-    set_package_properties(KF${QT_MAJOR_VERSION}FrameworkIntegration PROPERTIES
+        set_package_properties(KF${QT_MAJOR_VERSION}FrameworkIntegration PROPERTIES
             DESCRIPTION "KF${QT_MAJOR_VERSION} Framework Integration"
             URL "https://projects.kde.org/projects/frameworks/frameworkintegration"
             TYPE OPTIONAL

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ sudo eopkg install darkly
 
 Manifests should have the latest versions of KDE Runtime and SDK
 
-Build with `org.flatpak.Builder flatpak-build --repo=local --force-clean --ccache org.kde.KStyle.Darkly6.json` (use `org.kde.KStyle.Darkly6.json` for KF5)
-Bundle with `flatpak build-bundle darkly-master/ darkly.flatpak runtime/org.kde.KStyle.Darkly/x86_64/<runtime_version>`
+Build with `org.flatpak.Builder flatpak-build --repo=local --force-clean --ccache org.kde.KStyle.Darkly6.json` (use `org.kde.KStyle.Darkly5.json` for KF5)
+Bundle with `flatpak build-bundle local/ darkly.flatpak runtime/org.kde.KStyle.Darkly/x86_64/<runtime_version>`
 
 #### Void Linux
 

--- a/README.md
+++ b/README.md
@@ -226,10 +226,10 @@ echo "export QT_PLUGIN_PATH=$HOME/.local/lib64/plugins:\$QT_PLUGIN_PATH" > $HOME
 
 ---
 
-#### <u>Kubuntu (24.10)</u>
+#### <u>Kubuntu (25.04)</u>
 
 ```
-sudo apt-get install -y -qq cmake build-essential libkf5config-dev libkdecorations2-dev \
+sudo apt-get install -y -qq cmake build-essential libkf5config-dev libkdecorations3-dev \
       libqt5x11extras5-dev qtdeclarative5-dev extra-cmake-modules \
       libkf5guiaddons-dev libkf5configwidgets-dev libkf5windowsystem-dev kirigami2-dev \
       libkf5coreaddons-dev libkf5iconthemes-dev gettext qt3d5-dev libkf5kcmutils-dev \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > [!IMPORTANT]
 > If you use a distro that doesn't have plasma 6.3 yet, please use [v0.5.16](https://github.com/Bali10050/Darkly/releases/tag/v0.5.16) or the [Darkly\(6.2\)](https://github.com/Bali10050/Darkly/tree/Darkly(6.2)) branch.
-> 
+>
 > You can use this one if you want to, but it most likely won't work
 
 # About this fork
@@ -66,6 +66,13 @@ sudo eopkg install darkly
 `./install.sh QT6` will build & install using only QT6/KF6 dependencies.
 
 `./install.sh remove` will remove Darkly.
+
+### Flatpak
+
+Manifests should have the latest versions of KDE Runtime and SDK
+
+Build with `org.flatpak.Builder flatpak-build --repo=local --force-clean --ccache org.kde.KStyle.Darkly6.json` (use `org.kde.KStyle.Darkly6.json` for KF5)
+Bundle with `flatpak build-bundle darkly-master/ darkly.flatpak runtime/org.kde.KStyle.Darkly/x86_64/<runtime_version>`
 
 #### Void Linux
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,15 @@ environment.systemPackages = with pkgs; [
 
 ---
 
+#### <u>Flatpak</u>
+
+Manifests should have the latest versions of KDE Runtime and SDK
+
+Build with `org.flatpak.Builder flatpak-build --repo=local --force-clean --ccache org.kde.KStyle.Darkly6.json` (use `org.kde.KStyle.Darkly5.json` for KF5)
+Bundle with `flatpak build-bundle local/ darkly.flatpak runtime/org.kde.KStyle.Darkly/x86_64/<runtime_version>`
+
+---
+
 ## Known issues & solutions
 
 ### Blurred icon rendering on Wayland with fractional scaling

--- a/kstyle/CMakeLists.txt
+++ b/kstyle/CMakeLists.txt
@@ -111,10 +111,12 @@ endif()
 
 ########### install files ###############
 install(TARGETS darkly${QT_MAJOR_VERSION} DESTINATION ${KDE_INSTALL_QTPLUGINDIR}/styles/)
-install(FILES darkly.themerc  DESTINATION  ${KDE_INSTALL_DATADIR}/kstyle/themes)
+if (!FOR_FLATPAK)
+    install(FILES darkly.themerc  DESTINATION  ${KDE_INSTALL_DATADIR}/kstyle/themes)
+endif()
 
 ########### subdirectories ###############
 
-if (QT_MAJOR_VERSION EQUAL "6" AND TARGET "KF6::KCMUtils")
+if (QT_MAJOR_VERSION EQUAL "6" AND TARGET "KF6::KCMUtils" AND !FOR_FLATPAK)
     add_subdirectory(config)
 endif()

--- a/kstyle/CMakeLists.txt
+++ b/kstyle/CMakeLists.txt
@@ -110,7 +110,13 @@ endif()
 
 
 ########### install files ###############
-install(TARGETS darkly${QT_MAJOR_VERSION} DESTINATION ${KDE_INSTALL_QTPLUGINDIR}/styles/)
+if (FOR_FLATPAK)
+    set(LIB_TARGET ${QT_PLUGINS_DIR}/styles/)
+else()
+    set(LIB_TARGET ${KDE_INSTALL_QTPLUGINDIR}/styles/)
+endif()
+install(TARGETS darkly${QT_MAJOR_VERSION} DESTINATION ${LIB_TARGET})
+
 if (!FOR_FLATPAK)
     install(FILES darkly.themerc  DESTINATION  ${KDE_INSTALL_DATADIR}/kstyle/themes)
 endif()

--- a/kstyle/config/darklystyleconfig.cpp
+++ b/kstyle/config/darklystyleconfig.cpp
@@ -66,7 +66,7 @@ StyleConfig::StyleConfig(QWidget *parent)
     connect(_menuOpacity, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
     connect(_menuOpacity, SIGNAL(valueChanged(int)), _menuOpacitySpinBox, SLOT(setValue(int)));
     connect(_menuOpacitySpinBox, SIGNAL(valueChanged(int)), _menuOpacity, SLOT(setValue(int)));
-    connect(_buttonSize, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
+
     connect(_sidebarOpacity, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
     connect(_sidebarOpacity, SIGNAL(valueChanged(int)), _sidebarOpacitySpinBox, SLOT(setValue(int)));
     connect(_sidebarOpacitySpinBox, SIGNAL(valueChanged(int)), _sidebarOpacity, SLOT(setValue(int)));
@@ -105,6 +105,9 @@ StyleConfig::StyleConfig(QWidget *parent)
     connect(_tabUseBrighterCloseIcon, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
     connect(_disableDolphinUrlNavigatorBackground, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
     connect(_tabsHeight, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
+
+    connect(_buttonHeight, SIGNAL(valueChanged(int)), SLOT(updateChanged()));
+    connect(_buttonWidth, SIGNAL(valueChanged(int)), SLOT(updateChanged()));
 }
 
 //__________________________________________________________________
@@ -132,7 +135,6 @@ void StyleConfig::save()
     StyleConfigData::setMenuBarOpacity(_menuBarOpacity->value());
     StyleConfigData::setToolBarOpacity(_toolBarOpacity->value());
     StyleConfigData::setTabBarOpacity(_tabBarOpacity->value());
-    StyleConfigData::setButtonSize(_buttonSize->value());
     StyleConfigData::setKTextEditDrawFrame(_kTextEditDrawFrame->isChecked());
     StyleConfigData::setWidgetDrawShadow(_widgetDrawShadow->isChecked());
     StyleConfigData::setWidgetToolBarShadow(_widgetToolBarShadow->isChecked());
@@ -151,6 +153,8 @@ void StyleConfig::save()
     StyleConfigData::setTabUseBrighterCloseIcon(_tabUseBrighterCloseIcon->isChecked());
     StyleConfigData::setDisableDolphinUrlNavigatorBackground(_disableDolphinUrlNavigatorBackground->isChecked());
     StyleConfigData::setTabsHeight(_tabsHeight->value());
+    StyleConfigData::setButtonHeight(_buttonHeight->value());
+    StyleConfigData::setButtonWidth(_buttonWidth->value());
 
     StyleConfigData::self()->save();
 
@@ -217,9 +221,11 @@ void StyleConfig::updateChanged()
     else if (_menuOpacity->value() != StyleConfigData::menuOpacity()) {
         modified = true;
         _menuOpacitySpinBox->setValue(_menuOpacity->value());
-    } else if (_buttonSize->value() != StyleConfigData::buttonSize())
+    } else if (_buttonHeight->value() != StyleConfigData::buttonHeight()) {
         modified = true;
-    else if (_sidebarOpacity->value() != StyleConfigData::dolphinSidebarOpacity()) {
+    } else if (_buttonWidth->value() != StyleConfigData::buttonWidth()) {
+        modified = true;
+    } else if (_sidebarOpacity->value() != StyleConfigData::dolphinSidebarOpacity()) {
         modified = true;
         _sidebarOpacitySpinBox->setValue(_sidebarOpacity->value());
     } else if (_menuBarOpacity->value() != StyleConfigData::menuBarOpacity()) {
@@ -325,8 +331,8 @@ void StyleConfig::load()
     _toolBarOpacitySpinBox->setValue(StyleConfigData::toolBarOpacity());
     _tabBarOpacity->setValue(StyleConfigData::tabBarOpacity());
     _tabBarOpacitySpinBox->setValue(StyleConfigData::tabBarOpacity());
-
-    _buttonSize->setValue(StyleConfigData::buttonSize());
+    _buttonHeight->setValue(StyleConfigData::buttonHeight());
+    _buttonWidth->setValue(StyleConfigData::buttonWidth());
     _kTextEditDrawFrame->setChecked(StyleConfigData::kTextEditDrawFrame());
     _widgetDrawShadow->setChecked(StyleConfigData::widgetDrawShadow());
     _widgetToolBarShadow->setChecked(StyleConfigData::widgetToolBarShadow());

--- a/kstyle/config/ui/darklystyleconfig.ui
+++ b/kstyle/config/ui/darklystyleconfig.ui
@@ -75,123 +75,7 @@
        <property name="spacing">
         <number>13</number>
        </property>
-       <item row="52" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_18">
-         <item>
-          <widget class="QLabel" name="_mnemonicsLabel">
-           <property name="text">
-            <string>Keyboard accelerators visibility:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-           <property name="indent">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="_mnemonicsMode">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="layoutDirection">
-            <enum>Qt::LayoutDirection::LeftToRight</enum>
-           </property>
-           <item>
-            <property name="text">
-             <string>Always Hide</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>When Needed</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Always Show</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_12">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item row="51" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_17">
-         <item>
-          <widget class="QLabel" name="label_12">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Corner Radius:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-           <property name="indent">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="_cornerRadius">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="suffix">
-            <string> px</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>8</number>
-           </property>
-           <property name="value">
-            <number>6</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_9">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item row="53" column="0">
+       <item row="47" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_19">
          <item>
           <widget class="QLabel" name="_windowDragLabel">
@@ -258,107 +142,144 @@
          </item>
         </layout>
        </item>
-       <item row="3" column="0" rowspan="2" colspan="3">
-        <layout class="QGridLayout" name="gridLayout_4">
-         <property name="sizeConstraint">
-          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+       <item row="2" column="0" colspan="2">
+        <widget class="QCheckBox" name="_viewDrawFocusIndicator">
+         <property name="text">
+          <string>Draw focus indicator in lists</string>
          </property>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_2">
+        </widget>
+       </item>
+       <item row="46" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_18">
+         <item>
+          <widget class="QLabel" name="_mnemonicsLabel">
+           <property name="text">
+            <string>Keyboard accelerators visibility:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="_mnemonicsMode">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LayoutDirection::LeftToRight</enum>
+           </property>
+           <item>
+            <property name="text">
+             <string>Always Hide</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>When Needed</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Always Show</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_12">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QCheckBox" name="_toolBarDrawItemSeparator">
+         <property name="text">
+          <string>Draw toolbar item separators</string>
+         </property>
+        </widget>
+       </item>
+       <item row="45" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
+         <item>
+          <widget class="QLabel" name="label_12">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Button Size:</string>
+            <string>Corner Radius:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
           </widget>
          </item>
-         <item row="2" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_16">
-           <property name="sizeConstraint">
-            <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_4">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Smaller</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Bigger</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSlider" name="_buttonSize">
+         <item>
+          <widget class="QSpinBox" name="_cornerRadius">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="suffix">
+            <string> px</string>
+           </property>
            <property name="minimum">
-            <number>-2</number>
-           </property>
-           <property name="maximum">
-            <number>6</number>
-           </property>
-           <property name="singleStep">
             <number>1</number>
            </property>
-           <property name="sliderPosition">
-            <number>4</number>
+           <property name="maximum">
+            <number>8</number>
            </property>
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="tickPosition">
-            <enum>QSlider::TickPosition::TicksBelow</enum>
-           </property>
-           <property name="tickInterval">
-            <number>2</number>
+           <property name="value">
+            <number>6</number>
            </property>
           </widget>
          </item>
+         <item>
+          <spacer name="horizontalSpacer_9">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </item>
-       <item row="54" column="2">
+       <item row="0" column="0" colspan="2">
+        <widget class="QCheckBox" name="_scrollableMenu">
+         <property name="text">
+          <string>Scrollable popup menu</string>
+         </property>
+        </widget>
+       </item>
+       <item row="48" column="1">
         <widget class="QLabel" name="_versionNumber">
          <property name="font">
           <font>
@@ -376,25 +297,97 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0" colspan="3">
-        <widget class="QCheckBox" name="_viewDrawFocusIndicator">
-         <property name="text">
-          <string>Draw focus indicator in lists</string>
+       <item row="3" column="0" rowspan="2" colspan="2">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Increase button size</string>
          </property>
-        </widget>
-       </item>
-       <item row="0" column="0" colspan="3">
-        <widget class="QCheckBox" name="_scrollableMenu">
-         <property name="text">
-          <string>Scrollable popup menu</string>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="3">
-        <widget class="QCheckBox" name="_toolBarDrawItemSeparator">
-         <property name="text">
-          <string>Draw toolbar item separators</string>
+         <property name="flat">
+          <bool>false</bool>
          </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <widget class="QWidget" name="layoutWidget">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>30</y>
+            <width>621</width>
+            <height>42</height>
+           </rect>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_16">
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Height:</string>
+             </property>
+             <property name="indent">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="_buttonHeight">
+             <property name="suffix">
+              <string> px</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Width:</string>
+             </property>
+             <property name="indent">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="_buttonWidth">
+             <property name="suffix">
+              <string> px</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
@@ -1425,100 +1418,99 @@
         <string>Draw widget shadow</string>
        </property>
       </widget>
-      <widget class="QFrame" name="frame">
+      <widget class="QCheckBox" name="_widgetToolBarShadow">
        <property name="geometry">
         <rect>
-         <x>10</x>
-         <y>70</y>
-         <width>611</width>
-         <height>231</height>
+         <x>20</x>
+         <y>40</y>
+         <width>211</width>
+         <height>24</height>
         </rect>
        </property>
-       <property name="frameShape">
-        <enum>QFrame::Shape::NoFrame</enum>
+       <property name="text">
+        <string>Draw shadow under toolbar</string>
        </property>
-       <property name="frameShadow">
-        <enum>QFrame::Shadow::Plain</enum>
+      </widget>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>70</y>
+         <width>631</width>
+         <height>311</height>
+        </rect>
        </property>
-       <widget class="QLabel" name="label_16">
+       <property name="title">
+        <string>These settings change how menu shadow outlines are displayed</string>
+       </property>
+       <widget class="QWidget" name="">
         <property name="geometry">
          <rect>
-          <x>50</x>
-          <y>4</y>
-          <width>541</width>
-          <height>20</height>
+          <x>10</x>
+          <y>30</y>
+          <width>611</width>
+          <height>43</height>
          </rect>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::Shape::NoFrame</enum>
-        </property>
-        <property name="text">
-         <string>These settings change how menu shadow outlines are displayed</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignmentFlag::AlignCenter</set>
-        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_21">
+         <item>
+          <widget class="QLabel" name="label_13">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Size:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="indent">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="_shadowSize">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="currentIndex">
+            <number>-1</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
        </widget>
        <widget class="QWidget" name="gridLayoutWidget">
         <property name="geometry">
          <rect>
           <x>10</x>
-          <y>30</y>
-          <width>591</width>
+          <y>80</y>
+          <width>611</width>
           <height>198</height>
          </rect>
         </property>
         <layout class="QGridLayout" name="gridLayout_3">
-         <item row="0" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_21">
-           <item>
-            <widget class="QLabel" name="label_13">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Size:      </string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-             </property>
-             <property name="indent">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="_shadowSize">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="currentIndex">
-              <number>-1</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_5">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="2" column="0">
+         <item row="1" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_13">
            <item>
             <widget class="QLabel" name="label_17">
@@ -1532,10 +1524,10 @@
               <string>Intensity:</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
              <property name="indent">
-              <number>0</number>
+              <number>5</number>
              </property>
             </widget>
            </item>
@@ -1587,53 +1579,7 @@
            </item>
           </layout>
          </item>
-         <item row="1" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_14">
-           <item>
-            <widget class="QLabel" name="label_14">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Color:     </string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignCenter</set>
-             </property>
-             <property name="indent">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="KColorCombo" name="_shadowColor">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_6">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="3" column="0">
+         <item row="2" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_20">
            <item>
             <widget class="QLabel" name="label_15">
@@ -1650,7 +1596,7 @@
               <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
              <property name="indent">
-              <number>0</number>
+              <number>5</number>
              </property>
             </widget>
            </item>
@@ -1688,21 +1634,54 @@
            </item>
           </layout>
          </item>
+         <item row="0" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_14">
+           <item>
+            <widget class="QLabel" name="label_14">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Color:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+             <property name="indent">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="KColorCombo" name="_shadowColor">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_6">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
         </layout>
        </widget>
-      </widget>
-      <widget class="QCheckBox" name="_widgetToolBarShadow">
-       <property name="geometry">
-        <rect>
-         <x>20</x>
-         <y>40</y>
-         <width>211</width>
-         <height>24</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Draw shadow under toolbar</string>
-       </property>
       </widget>
      </widget>
     </widget>

--- a/kstyle/darkly.h
+++ b/kstyle/darkly.h
@@ -44,7 +44,7 @@ using ScopedPointer = QScopedPointer<T, QScopedPointerPodDeleter>;
 //* metrics
 enum Metrics {
     // frames
-    Frame_FrameWidth = 5,
+    Frame_FrameWidth = 2,
     // Frame_FrameRadius = 6,
 
     // layout

--- a/kstyle/darkly.kcfg
+++ b/kstyle/darkly.kcfg
@@ -1,63 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kcfg xmlns="http://www.kde.org/standards/kcfg/1.0"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
 
-  <kcfgfile name="darklyrc"/>
+  <kcfgfile name="darklyrc" />
 
   <!-- common options -->
   <group name="Common">
 
     <!-- shadow strength-->
-    <entry name="ShadowStrength" type = "Int">
-       <default>255</default>
-       <min>25</min>
-       <max>255</max>
+    <entry name="ShadowStrength" type="Int">
+      <default>255</default>
+      <min>25</min>
+      <max>255</max>
     </entry>
 
     <!-- shadow size -->
-    <entry name="ShadowSize" type = "Enum">
+    <entry name="ShadowSize" type="Enum">
       <choices>
-          <choice name="ShadowNone"/>
-          <choice name="ShadowSmall"/>
-          <choice name="ShadowMedium"/>
-          <choice name="ShadowLarge"/>
-          <choice name="ShadowVeryLarge"/>
+        <choice name="ShadowNone" />
+        <choice name="ShadowSmall" />
+        <choice name="ShadowMedium" />
+        <choice name="ShadowLarge" />
+        <choice name="ShadowVeryLarge" />
       </choices>
       <default>ShadowLarge</default>
     </entry>
 
     <!-- shadow color -->
-    <entry name="ShadowColor" type = "Color">
-       <default>0, 0, 0</default>
+    <entry name="ShadowColor" type="Color">
+      <default>0, 0, 0</default>
     </entry>
 
     <!-- shadow intensity -->
-     <entry name="ShadowIntensity" type = "Enum">
-       <choices>
-          <choice name="Low"/>
-          <choice name="Medium"/>
-          <choice name="High"/>
-          <choice name="Maximum"/>
+    <entry name="ShadowIntensity" type="Enum">
+      <choices>
+        <choice name="Low" />
+        <choice name="Medium" />
+        <choice name="High" />
+        <choice name="Maximum" />
       </choices>
       <default>Medium</default>
     </entry>
 
     <!-- close button -->
-    <entry name="OutlineCloseButton" type = "Bool">
-        <default>false</default>
+    <entry name="OutlineCloseButton" type="Bool">
+      <default>false</default>
     </entry>
-    
+
     <!-- corner radius -->
-    <entry name="CornerRadius" type = "Int">
-       <default>6</default>
-       <min>1</min>
-       <max>8</max>
+    <entry name="CornerRadius" type="Int">
+      <default>6</default>
+      <min>1</min>
+      <max>8</max>
     </entry>
 
     <!-- button size -->
-    <entry name="ButtonSize" type="Int">
-        <default>4</default>
+    <entry name="ButtonHeight" type="Int">
+      <default>3</default>
+    </entry>
+
+    <entry name="ButtonWidth" type="Int">
+      <default>3</default>
     </entry>
   </group>
 
@@ -69,15 +73,15 @@
       <default>true</default>
     </entry>
 
-    <entry name="AnimationSteps" type = "Int">
-       <default>30</default>
+    <entry name="AnimationSteps" type="Int">
+      <default>30</default>
     </entry>
 
     <entry name="AnimationsDuration" type="Int">
       <default>250</default>
     </entry>
 
-   <!-- transition flags -->
+    <!-- transition flags -->
     <entry name="StackedWidgetTransitionsEnabled" type="Bool">
       <default>false</default>
     </entry>
@@ -104,9 +108,9 @@
     <!-- mnemonics -->
     <entry name="MnemonicsMode" type="Enum">
       <choices>
-          <choice name="MN_NEVER" />
-          <choice name="MN_AUTO" />
-          <choice name="MN_ALWAYS" />
+        <choice name="MN_NEVER" />
+        <choice name="MN_AUTO" />
+        <choice name="MN_ALWAYS" />
       </choices>
       <default>MN_AUTO</default>
     </entry>
@@ -115,7 +119,7 @@
     <entry name="ToolBarDrawItemSeparator" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <entry name="ToolBarDrawSeparator" type="Bool">
       <default>false</default>
     </entry>
@@ -124,11 +128,11 @@
     <entry name="ViewDrawFocusIndicator" type="Bool">
       <default>true</default>
     </entry>
-    
+
     <entry name="TransparentDolphinView" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <!-- shadows on widgets -->
     <entry name="WidgetDrawShadow" type="Bool">
       <default>true</default>
@@ -142,7 +146,7 @@
     <entry name="ScrollableMenu" type="Bool">
       <default>true</default>
     </entry>
-    
+
     <entry name="OldTabbar" type="Bool">
       <default>false</default>
     </entry>
@@ -160,19 +164,19 @@
     <entry name="TabBarAltStyle" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <entry name="TabBarDrawCenteredTabs" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <entry name="TabBarTabExpandFullWidth" type="Bool">
       <default>true</default>
     </entry>
-    
+
     <entry name="TabDrawHighlight" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <entry name="UnifiedTabBarKonsole" type="Bool">
       <default>false</default>
     </entry>
@@ -189,7 +193,7 @@
       <default>true</default>
     </entry>
 
-     <entry name="TabUseBrighterCloseIcon" type="Bool">
+    <entry name="TabUseBrighterCloseIcon" type="Bool">
       <default>false</default>
     </entry>
 
@@ -205,7 +209,7 @@
     <entry name="DockWidgetDrawFrame" type="Bool">
       <default>false</default>
     </entry>
-    
+
     <entry name="KTextEditDrawFrame" type="Bool">
       <default>false</default>
     </entry>
@@ -225,9 +229,9 @@
     <!-- window dragging -->
     <entry name="WindowDragMode" type="Enum">
       <choices>
-          <choice name="WD_NONE" />
-          <choice name="WD_MINIMAL" />
-          <choice name="WD_FULL" />
+        <choice name="WD_NONE" />
+        <choice name="WD_MINIMAL" />
+        <choice name="WD_FULL" />
       </choices>
       <default>WD_FULL</default>
     </entry>
@@ -238,7 +242,7 @@
         standard widgets. They are reference by the widget class name.
     -->
     <entry name="WindowDragWhiteList" type="StringList">
-       <default></default>
+      <default></default>
     </entry>
 
     <!--
@@ -247,19 +251,19 @@
         standard widgets). They are reference by the widget class name.
     -->
     <entry name="WindowDragBlackList" type="StringList">
-       <default></default>
+      <default></default>
     </entry>
-    
+
     <!-- 
         this is the comma separated list of special apps that should have no
         transparency.
     -->
     <entry name="OpaqueApps" type="StringList">
-       <default></default>
+      <default></default>
     </entry>
-    
+
     <entry name="ForceOpaque" type="StringList">
-       <default>kscreenlocker,wine,vlc,kdevelop,smplayer,virtualbox,virtualboxvm,obs,kaffeine,kstars,digikam,kdenlive</default>
+      <default>kscreenlocker,wine,vlc,kdevelop,smplayer,virtualbox,virtualboxvm,obs,kaffeine,kstars,digikam,kdenlive</default>
     </entry>
 
     <!-- if true, move events are passed to the window manager (e.g. KWin) -->
@@ -287,11 +291,11 @@
 
     <!-- transparency -->
     <entry name="MenuOpacity" type="Int">
-        <default>100</default>
+      <default>100</default>
     </entry>
-    
+
     <entry name="DolphinSidebarOpacity" type="Int">
-        <default>100</default>
+      <default>100</default>
     </entry>
 
     <entry name="MenuBarOpacity" type="Int">
@@ -299,17 +303,17 @@
     </entry>
 
     <entry name="ToolBarOpacity" type="Int">
-        <default>100</default>
+      <default>100</default>
     </entry>
 
-     <entry name="TabBarOpacity" type="Int">
-        <default>100</default>
+    <entry name="TabBarOpacity" type="Int">
+      <default>100</default>
     </entry>
 
     <entry name="AdjustToDarkThemes" type="Bool">
       <default>false</default>
     </entry>
-    <entry name="TabBGColor" type = "Color">
+    <entry name="TabBGColor" type="Color">
       <default>0, 0, 0</default>
     </entry>
   </group>

--- a/kstyle/darklyblurhelper.h
+++ b/kstyle/darklyblurhelper.h
@@ -82,6 +82,8 @@ protected:
 
     QRegion blurTabWidgetRegion(QWidget *widget) const;
 
+    QRegion blurSettingsDialogRegion(QWidget *widget) const;
+
     //! update blur regions for given widget
     void update(QWidget *) const;
 

--- a/kstyle/darklyhelper.cpp
+++ b/kstyle/darklyhelper.cpp
@@ -686,13 +686,9 @@ void Helper::renderButtonFrame(QPainter *painter,
 
     painter->setPen(Qt::NoPen);
 
-    // copy rect
-    QRectF frameRect(rect);
-
     // reduce the size of the actual button, the rest will be the shadow
-    frameRect.adjust(5, 5, -5, -5);
-
-    qreal radius(frameRadius() - 1);
+    QRectF frameRect(rect.adjusted(Metrics::Frame_FrameWidth, Metrics::Frame_FrameWidth, -Metrics::Frame_FrameWidth, -Metrics::Frame_FrameWidth));
+    qreal radius(frameRadius() - qreal(Metrics::Frame_FrameWidth));
 
     if (sunken) {
         frameRect.translate(0, 1);
@@ -1717,7 +1713,7 @@ bool Helper::isWayland()
 }
 
 //______________________________________________________________________________
-QRectF Helper::strokedRect(const QRectF &rect, const int penWidth) const
+QRectF Helper::strokedRect(const QRectF &rect, const qreal penWidth) const
 {
     /* With a pen stroke width of 1, the rectangle should have each of its
      * sides moved inwards by half a pixel. This allows the stroke to be
@@ -1727,11 +1723,6 @@ QRectF Helper::strokedRect(const QRectF &rect, const int penWidth) const
      */
     qreal adjustment = 0.5 * penWidth;
     return QRectF(rect).adjusted(adjustment, adjustment, -adjustment, -adjustment);
-}
-
-QRectF Helper::strokedRect(const QRect &rect, const int penWidth) const
-{
-    return strokedRect(QRectF(rect), penWidth);
 }
 
 //______________________________________________________________________________

--- a/kstyle/darklyhelper.h
+++ b/kstyle/darklyhelper.h
@@ -420,10 +420,13 @@ public:
     }
 
     //* return a QRectF with the appropriate size for a rectangle with a pen stroke
-    QRectF strokedRect(const QRectF &rect, const int penWidth = PenWidth::Frame) const;
+    QRectF strokedRect(const QRectF &rect, const qreal penWidth = PenWidth::Frame) const;
 
-    //* return a QRectF with the appropriate size for a rectangle with a pen stroke
-    QRectF strokedRect(const QRect &rect, const int penWidth = PenWidth::Frame) const;
+    //* return a QRectF with the appropriate size for a rectangle with a shadow around it
+    QRectF shadowedRect(const QRectF &rect, const qreal shadowSize = PenWidth::Shadow) const
+    {
+        return rect.adjusted(shadowSize, shadowSize, -shadowSize, -shadowSize);
+    }
 
     QPixmap coloredIcon(const QIcon &icon,
                         const QPalette &palette,

--- a/kstyle/darklystyle.h
+++ b/kstyle/darklystyle.h
@@ -139,7 +139,6 @@ public:
 
     bool eventFilter(QObject *, QEvent *) override;
     bool eventFilterScrollArea(QWidget *, QEvent *);
-    bool eventFilterDolphinUrlNavigator(QWidget *, QEvent *);
     bool eventFilterComboBoxContainer(QWidget *, QEvent *);
     bool eventFilterDockWidget(QDockWidget *, QEvent *);
     bool eventFilterMdiSubWindow(QMdiSubWindow *, QEvent *);

--- a/org.kde.KStyle.Darkly5.json
+++ b/org.kde.KStyle.Darkly5.json
@@ -1,0 +1,32 @@
+{
+  "id": "org.kde.KStyle.Darkly",
+  "branch": "5.15-24.08",
+  "runtime": "org.kde.Platform",
+  "build-extension": true,
+  "sdk": "org.kde.Sdk",
+  "runtime-version": "5.15-24.08",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Darkly",
+      "buildsystem": "cmake",
+      "builddir": true,
+      "config-opts": [
+        "-DQT_PLUGINS_DIR=/usr/share/runtime/lib/plugins/Darkly",
+        "-DCMAKE_INSTALL_PREFIX=/usr/share/runtime/lib/plugins/Darkly",
+        "-DBUILD_QT6=OFF",
+        "-DBUILD_QT5=ON",
+        "-DWITH_DECORATIONS=OFF",
+        "-DFOR_FLATPAK=ON"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/Bali10050/Darkly",
+          "branch": "main"
+        }
+      ]
+    }
+  ]
+}

--- a/org.kde.KStyle.Darkly5.json
+++ b/org.kde.KStyle.Darkly5.json
@@ -23,7 +23,7 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/Bali10050/Darkly",
+          "url": "https://github.com/MicrogamerCz/Darkly-flatpak",
           "branch": "main"
         }
       ]

--- a/org.kde.KStyle.Darkly5.json
+++ b/org.kde.KStyle.Darkly5.json
@@ -23,7 +23,7 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/MicrogamerCz/Darkly-flatpak",
+          "url": "https://github.com/Bali10050/Darkly",
           "branch": "main"
         }
       ]

--- a/org.kde.KStyle.Darkly6.json
+++ b/org.kde.KStyle.Darkly6.json
@@ -1,0 +1,32 @@
+{
+  "id": "org.kde.KStyle.Darkly",
+  "branch": "6.8",
+  "runtime": "org.kde.Platform",
+  "build-extension": true,
+  "sdk": "org.kde.Sdk",
+  "runtime-version": "6.9",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Darkly",
+      "buildsystem": "cmake",
+      "builddir": true,
+      "config-opts": [
+        "-DQT_PLUGINS_DIR=/usr/share/runtime/lib/plugins/Darkly",
+        "-DCMAKE_INSTALL_PREFIX=/usr/share/runtime/lib/plugins/Darkly",
+        "-DBUILD_QT6=ON",
+        "-DBUILD_QT5=OFF",
+        "-DWITH_DECORATIONS=OFF",
+        "-DFOR_FLATPAK=ON"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/Bali10050/Darkly",
+          "branch": "main"
+        }
+      ]
+    }
+  ]
+}

--- a/org.kde.KStyle.Darkly6.json
+++ b/org.kde.KStyle.Darkly6.json
@@ -4,7 +4,7 @@
   "runtime": "org.kde.Platform",
   "build-extension": true,
   "sdk": "org.kde.Sdk",
-  "runtime-version": "6.9",
+  "runtime-version": "6.8",
   "appstream-compose": false,
   "separate-locales": false,
   "modules": [

--- a/org.kde.KStyle.Darkly6.json
+++ b/org.kde.KStyle.Darkly6.json
@@ -23,7 +23,7 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/Bali10050/Darkly",
+          "url": "https://github.com/MicrogamerCz/Darkly-flatpak",
           "branch": "main"
         }
       ]

--- a/org.kde.KStyle.Darkly6.json
+++ b/org.kde.KStyle.Darkly6.json
@@ -23,7 +23,7 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/MicrogamerCz/Darkly-flatpak",
+          "url": "https://github.com/Bali10050/Darkly",
           "branch": "main"
         }
       ]


### PR DESCRIPTION
Bringing flatpak support for Darkly.

From what was mentioned in #91
- XDG Desktop Portal can't solve the issue, ever. Qt styles are system binaries, not .css files in user-space.
- My fork for Lightly was *heavily* butchered, as the only point was flatpak support and it couldn't have been merged at all

The changes are really light, only adding CMake build option and instructions for flatpak in README, excluding unnecessary components - color scheme, KDecoration, config applet and installed config cmake files

Tested on the following apps and their respective runtimes:
```
[x] org.sqlitebrowser.sqlitebrowser                     org.kde.Platform/x86_64/5.15-24.08
[x] org.torproject.torbrowser-launcher                  org.kde.Platform/x86_64/5.15-24.08
[x] io.github.input_leap.input-leap                     org.kde.Platform/x86_64/6.8
[x] org.kde.audiotube                                   org.kde.Platform/x86_64/6.8
[x] org.kde.elisa                                       org.kde.Platform/x86_64/6.8
[x] org.kde.kcalc                                       org.kde.Platform/x86_64/6.8
[x] org.kde.kcharselect                                 org.kde.Platform/x86_64/6.8
[x] org.kde.kclock                                      org.kde.Platform/x86_64/6.8
[x] org.kde.kdenlive                                    org.kde.Platform/x86_64/6.8
[x] org.kde.keysmith                                    org.kde.Platform/x86_64/6.8
[x] org.kde.kid3                                        org.kde.Platform/x86_64/6.8
[x] org.kde.kiten                                       org.kde.Platform/x86_64/6.8
[x] org.kde.klevernotes                                 org.kde.Platform/x86_64/6.8
[x] org.kde.kwrite                                      org.kde.Platform/x86_64/6.8
[x] org.kde.marknote                                    org.kde.Platform/x86_64/6.8
[x] org.kde.skanlite                                    org.kde.Platform/x86_64/6.8
[ ] org.nickvision.tubeconverter                        org.kde.Platform/x86_64/6.8
[x] org.prismlauncher.PrismLauncher                     org.kde.Platform/x86_64/6.8
[x] org.kde.gwenview                                    org.kde.Platform/x86_64/6.9
[x] org.kde.haruna                                      org.kde.Platform/x86_64/6.9
[x] org.kde.karp                                        org.kde.Platform/x86_64/6.9
[x] org.kde.kirigami2.gallery                           org.kde.Platform/x86_64/6.9
[x] org.kde.okular                                      org.kde.Platform/x86_64/6.9
[x] org.qbittorrent.qBittorrent                         org.kde.Platform/x86_64/6.9
```

Only parabolic doesn't work, because they hard-code the QStyle

The manifests already contain URL for this repo, if any contributor wants to check it first, they should change the source url for my fork. Changing the version of Runtime/SDK needs to be done manually as well for 6.X versions

---

Edit: At first, I forked only the main branch, so with a few manual changes, I synced it with the Feature branch (last two commits in this PR), although there seem to be more changes than intended.

In any case, changes for flatpak support are affecting the following files only:
- org.kde.KStyle.Darkly6.json
- org.kde.KStyle.Darkly5.json 
- CMakeLists.txt
- README.md (optional, intructions for building the flatpak package)
- kstyle/CMakeLists.txt