### PR TITLE
Fix for telegram crash

### DIFF
--- a/kstyle/darkly.kcfg
+++ b/kstyle/darkly.kcfg
@@ -272,7 +272,7 @@
     </entry>
 
     <entry name="ForceOpaque" type="StringList">
-      <default>kscreenlocker,wine,vlc,kdevelop,smplayer,virtualbox,virtualboxvm,obs,kaffeine,kstars,digikam,kdenlive,TelegramDesktop,AyuGramDesktop</default>
+      <default>kscreenlocker,wine,vlc,kdevelop,smplayer,virtualbox,virtualboxvm,obs,kaffeine,kstars,digikam,kdenlive,telegramdesktop,ayugramdesktop</default>
     </entry>
 
     <!-- if true, move events are passed to the window manager (e.g. KWin) -->


### PR DESCRIPTION
Reproduced bug mentioned in #204
Open either the telegram or ayugram app
Clicking on Settings > Profile > then close the dialog window - crashes the app.

Traced the issue down to transparency.
For example setting the sidebar opacity to anything < 100% causes a crash.

Updating the ForceOpaque list with the telegram app names bypasses the polish() part of the code and in effect skips applying any transparency effects on those apps causing a segmentation fault.

