### PR TITLE
Fix for segmentation faults in kate, telegram apps

### DIFF
--- a/kstyle/darkly.kcfg
+++ b/kstyle/darkly.kcfg
@@ -272,7 +272,7 @@
     </entry>
 
     <entry name="ForceOpaque" type="StringList">
-      <default>kscreenlocker,wine,vlc,kdevelop,smplayer,virtualbox,virtualboxvm,obs,kaffeine,kstars,digikam,kdenlive,telegramdesktop,ayugramdesktop</default>
+      <default>kscreenlocker,wine,vlc,kdevelop,smplayer,virtualbox,virtualboxvm,obs,kaffeine,kstars,digikam,kdenlive</default>
     </entry>
 
     <!-- if true, move events are passed to the window manager (e.g. KWin) -->

--- a/kstyle/darklyblurhelper.cpp
+++ b/kstyle/darklyblurhelper.cpp
@@ -338,30 +338,32 @@ QRegion BlurHelper::blurTabWidgetRegion(QWidget *widget) const
 QRegion BlurHelper::blurSettingsDialogRegion(QWidget *widget) const
 {
     QRegion region;
-    QList<QWidget *> widgets = widget->findChildren<QWidget *>();
 
     // settings only change it for konsole or dolphin about window
     if ((widget->windowFlags() & Qt::WindowType_Mask) == Qt::Dialog
         && (widget->inherits("KAboutApplicationDialog") || widget->inherits("KDEPrivate::KAboutKdeDialog"))) {
-        for (auto w : widgets) {
-            if (qobject_cast<QTabWidget *>(w) && (widget->inherits("KAboutApplicationDialog") || widget->inherits("KDEPrivate::KAboutKdeDialog"))) {
-                // about dialog
-                const QTabWidget *tw = qobject_cast<QTabWidget *>(w);
-                QSize tbSize(tw->rect().size());
-                // the blur region is too small without adjusting the height of the tabbar height
-                tbSize.setHeight(tw->tabBar()->rect().height() + 4);
-                region += roundedRegion(QRect(tw->pos(), tbSize), StyleConfigData::cornerRadius(), false, false, true, false);
-            } else {
-                // settings main dialog
-                region += roundedRegion(QRect(w->mapToGlobal(w->pos()), w->rect().size()), StyleConfigData::cornerRadius(), false, false, true, false);
-            }
-            if (w->inherits("KPageWidget")) {
-                // sidebar
-                QList<QWidget *> KPageWidgets = w->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly);
-                for (auto wid : KPageWidgets) {
-                    if (wid->property(PropertyNames::sidePanelView).toBool()) {
-                        region += roundedRegion(QRect(wid->pos(), wid->rect().size()), StyleConfigData::cornerRadius(), false, false, true, false);
-                        break;
+        QList<QWidget *> widgets = widget->findChildren<QWidget *>();
+        if (widgets.length() > 0) {
+            for (auto w : widgets) {
+                if (qobject_cast<QTabWidget *>(w) && (widget->inherits("KAboutApplicationDialog") || widget->inherits("KDEPrivate::KAboutKdeDialog"))) {
+                    // about dialog
+                    const QTabWidget *tw = qobject_cast<QTabWidget *>(w);
+                    QSize tbSize(tw->rect().size());
+                    // the blur region is too small without adjusting the height of the tabbar height
+                    tbSize.setHeight(tw->tabBar()->rect().height() + 4);
+                    region += roundedRegion(QRect(tw->pos(), tbSize), StyleConfigData::cornerRadius(), false, false, true, false);
+                } else {
+                    // settings main dialog
+                    region += roundedRegion(QRect(w->mapToGlobal(w->pos()), w->rect().size()), StyleConfigData::cornerRadius(), false, false, true, false);
+                }
+                if (w->inherits("KPageWidget")) {
+                    // sidebar
+                    QList<QWidget *> KPageWidgets = w->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly);
+                    for (auto wid : KPageWidgets) {
+                        if (wid->property(PropertyNames::sidePanelView).toBool()) {
+                            region += roundedRegion(QRect(wid->pos(), wid->rect().size()), StyleConfigData::cornerRadius(), false, false, true, false);
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
To replicate set the opacity level to < 100 for example the dolphin sidebar.

Kate causes a segmentation fault when closing the application via ctrl + q
The backtrace shows an issue with:

`#13 0x00007f526737119d _ZNK6Darkly10BlurHelper24blurSettingsDialogRegionEP7QWidget (darkly6.so + 0x5c19d)`

I've reverted the changes made in #217 since the new changes made as part of this pull also fixes #204

Please test whether this still works.