### PR TITLE
Windows Decoration: Add hide from screencast button

### DIFF
--- a/kdecoration/darklybutton.cpp
+++ b/kdecoration/darklybutton.cpp
@@ -272,6 +272,28 @@ void Button::drawIcon(QPainter *painter) const
             break;
         }
 
+        case DecorationButtonType::ExcludeFromCapture: {
+            // A spy hat (like view-private.svg icon)
+            const qreal cx = 9, cy = 9;
+            // Hat crown with dip/crease at top (filled)
+            std::array crownPoints{QPointF(cx - 4.1, cy - 2.5),
+                                   QPointF(cx - 3.2, cy - 6.1),
+                                   QPointF(cx, cy - 5),
+                                   QPointF(cx + 3.2, cy - 6.1),
+                                   QPointF(cx + 4.1, cy - 2.5)};
+            painter->setBrush(pen.color());
+            painter->drawPolygon(crownPoints.data(), crownPoints.size());
+            painter->setBrush(Qt::NoBrush);
+            // Hat brim
+            painter->drawLine(QPointF(cx - 6.2, cy - 0.5), QPointF(cx + 6.2, cy - 0.5));
+            // Glasses' lenses
+            painter->drawEllipse(QPointF(cx - 4, cy + 3.8), 2.3, 2.3);
+            painter->drawEllipse(QPointF(cx + 4, cy + 3.8), 2.3, 2.3);
+            // Bridge between lenses
+            painter->drawLine(QPointF(cx - 1.5, cy + 3.8), QPointF(cx + 1.5, cy + 3.8));
+            break;
+        }
+
         case DecorationButtonType::ApplicationMenu: {
             painter->drawRect(QRectF(3.5, 4.5, 11, 1));
             painter->drawRect(QRectF(3.5, 8.5, 11, 1));
@@ -310,7 +332,8 @@ QColor Button::foregroundColor() const
     } else if (type() == DecorationButtonType::Close && d->internalSettings()->outlineCloseButton()) {
         return d->titleBarColor();
 
-    } else if ((type() == DecorationButtonType::KeepBelow || type() == DecorationButtonType::KeepAbove || type() == DecorationButtonType::Shade)
+    } else if ((type() == DecorationButtonType::KeepBelow || type() == DecorationButtonType::KeepAbove || type() == DecorationButtonType::Shade
+                || type() == DecorationButtonType::ExcludeFromCapture)
                && isChecked()) {
         return d->titleBarColor();
 
@@ -343,7 +366,8 @@ QColor Button::backgroundColor() const
     } else if ((type() == DecorationButtonType::KeepBelow || type() == DecorationButtonType::KeepAbove || type() == DecorationButtonType::Shade)
                && isChecked()) {
         return d->fontColor();
-
+    } else if (type() == DecorationButtonType::ExcludeFromCapture && isChecked()) {
+        return c->color(ColorGroup::Warning, ColorRole::Foreground);
     } else if (m_animation->state() == QAbstractAnimation::Running) {
         if (type() == DecorationButtonType::Close) {
             if (d->internalSettings()->outlineCloseButton()) {


### PR DESCRIPTION
#290 

Added from https://invent.kde.org/plasma/breeze/-/merge_requests/571

<img width="1339" height="673" alt="Screenshot_20260226_091627" src="https://github.com/user-attachments/assets/a2bb3b26-943f-425a-87fa-9e05e556b662" />
