### PR TITLE
Fedora: Use latest docker image

### DIFF
--- a/.github/workflows/darkly-ci.yml
+++ b/.github/workflows/darkly-ci.yml
@@ -90,7 +90,7 @@ jobs:
     with:
       cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
       version: ${{ needs.release-ci.outputs.VERSION }}
-      containers: "['fedora:42','fedora:43']"
+      containers: "['fedora:42','fedora:43','fedora:latest']"
 
   Archlinux:
     needs: release-ci


### PR DESCRIPTION
Adds support for Fedora44 which is now the latest.
https://hub.docker.com/_/fedora#supported-tags-and-respective-dockerfile-links