### PR TITLE
#315: Disable widget shadows for certain applications

### DIFF
--- a/kstyle/darkly.kcfg
+++ b/kstyle/darkly.kcfg
@@ -55,6 +55,11 @@
       <default>Medium</default>
     </entry>
 
+    <!-- disable widget shadow on certain application -->
+    <entry name="ForceNoShadow" type="StringList">
+      <default>plasmazones-settings,plasmazones-editor</default>
+    </entry>
+
     <!-- close button -->
     <entry name="OutlineCloseButton" type="Bool">
       <default>false</default>

--- a/kstyle/darklyhelper.cpp
+++ b/kstyle/darklyhelper.cpp
@@ -586,7 +586,7 @@ void Helper::renderOutline(QPainter *painter, const QRectF &rect, const int radi
 //______________________________________________________________________________
 void Darkly::Helper::renderBoxShadow(QPainter *painter, const QRect &rect, int xOffset, int yOffset, int blurRadius, const QColor &, int cornerRadius, bool, TileSet::Tiles) const
 {
-    if (!StyleConfigData::widgetDrawShadow() || blurRadius <= 0)
+    if (!StyleConfigData::widgetDrawShadow() || blurRadius <= 0 || StyleConfigData::forceNoShadow().contains(QApplication::applicationName(), Qt::CaseInsensitive))
     return;
 
     const QColor shadowColor(0, 0, 0, 40);


### PR DESCRIPTION
Enabling widget shadows caused segmentation faults when loading both plasmazones-editor and plasmazones-settings.

Tracked down the issue to the use of `QGraphicsScene` here: https://github.com/Bali10050/Darkly/blob/158eb5afa70c3e2a96ca58a8bc512ae65aecaa4b/kstyle/darklyhelper.cpp#L614

This part of the code is working on every other application such as Dolphin, Konsole, Discover, Akregator ... I do not think it is necessary to make any drastic changes here; especially if it is currently working and could potentially cause regressions elsewhere.

**Changes**

Added a new entry `ForceNoShadow` into the config to essentially disable widget shadows entirely for certain applications. For applications such as plasmazones-settings and plasmazones-editor there is no difference when I compared the appearance with Breeze.

**Testing**

Both plasmazones applications now opens.

plasmazones-settings

<img width="1421" height="842" alt="image" src="https://github.com/user-attachments/assets/34950ad7-9e4b-4cb7-af34-b557b3542071" />

plasmazones-editor

<img width="1679" height="940" alt="image" src="https://github.com/user-attachments/assets/68522c15-409a-46bb-967d-63cd79431d36" />

If there is a better solution please let me know.

Thanks.