### PR TITLE
Fix floating title bar separator appearing when disabled

### DIFF
--- a/kdecoration/darklydecoration.cpp
+++ b/kdecoration/darklydecoration.cpp
@@ -932,6 +932,9 @@ void Decoration::paintTitleBar(QPainter *painter, const QRectF &repaintRegion)
         }
     }
 
+    painter->restore();
+
+if (m_internalSettings->floatingTitlebar()){
     const QColor outlineColor(this->outlineColor());
     if (!c->isShaded() && outlineColor.isValid()) {
         // outline
@@ -940,9 +943,6 @@ void Decoration::paintTitleBar(QPainter *painter, const QRectF &repaintRegion)
         painter->setPen(outlineColor);
         painter->drawLine(m_titleRect.bottomLeft(), m_titleRect.bottomRight());
     }
-
-    painter->restore();
-if (m_internalSettings->floatingTitlebar()){
 
     // draw caption
     painter->setFont(s->font());


### PR DESCRIPTION
**Description**
Fixes an issue where a visible separator line appeared between the title bar and main window even when the floating title bar feature was disabled. The separator was particularly noticeable at higher scaling levels (120%, 145%).

**Root Cause**
The separator was being drawn unconditionally in the paintTitleBar() function before checking whether the floating title bar was enabled. This caused it to render in both floating and non-floating title bar modes.

**Changes**
Moved the separator drawing code inside the if (m_internalSettings->floatingTitlebar()) conditional block
The separator now only renders when the floating title bar is actually enabled
The traditional (non-floating) title bar path no longer draws this separator

**File Changed**
darklydecoration.cpp - Decoration::paintTitleBar() function

**Testing**
The separator no longer appears when floating title bar is disabled
No visual changes when floating title bar is enabled
Should resolve the issue across all scaling levels

**Closes**
Fixes #320