### PR TITLE
Fix dark url navigator band in Dolphin with DisableDolphinUrlNavigatorBackground

### DIFF
--- a/kstyle/darklystyle.cpp
+++ b/kstyle/darklystyle.cpp
@@ -4204,6 +4204,18 @@ bool Style::drawFrameLineEditPrimitive(const QStyleOption *option, QPainter *pai
     bool isVisible = false;
     const auto isControl = isQtQuickControl(option, widget);
 
+    if (_isDolphin && !isControl && widget && widget->inherits("DolphinUrlNavigator")
+        && StyleConfigData::disableDolphinUrlNavigatorBackground() && StyleConfigData::toolBarOpacity() >= 100
+        && background.alpha() != 0) {
+        // with an opaque toolbar the url navigator should blend into it: fill the bar
+        // flat with the window (toolbar) color and skip renderLineEdit entirely.
+        // a transparent fill lets the line edit's box shadow/outline show through,
+        // painting a dark band and halo around the bar (seen with KIO 6, where
+        // KUrlNavigator paints PE_FrameLineEdit itself in breadcrumb mode)
+        painter->fillRect(rect, palette.color(QPalette::Window));
+        return true;
+    }
+
     if (_isDolphin && !isControl) {
         // take precautions only change this on the Dolphin location bar
         if (widget->inherits("DolphinUrlNavigator")) {


### PR DESCRIPTION
When "Disable Dolphin URL navigator background" is on and the toolbar is opaque, the location bar in Dolphin is drawn as a dark band with a darker outline around it instead of blending into the toolbar.

With KIO 6, KUrlNavigator always keeps its KUrlComboBox child (hidden in breadcrumb mode) and paints its PE_FrameLineEdit background itself in KUrlNavigator::paintEvent. drawFrameLineEditPrimitive then sets the background fully transparent (setAlphaF(0)), but renderLineEdit still draws its box shadow and outline, and with no opaque fill on top they stay visible over the toolbar. Measured on Plasma 6.7 / KIO 6.28 / Dolphin 26.04: toolbar #1F1F1F, the bar flat #1A1A1A, which is exactly the toolbar color darkened by the alpha 40 box shadow.

Fix: when the option is on and the toolbar is opaque, fill the bar with the window color and skip renderLineEdit. The translucent toolbar path (toolBarOpacity < 100) is left unchanged. Editable location mode is unaffected, KUrlNavigator does not paint PE_FrameLineEdit there.

Tested on Darkly master, Plasma 6.7 Wayland, KIO 6.28, Dolphin 26.04. After the patch the bar is pixel identical to the toolbar, no halo around it.