### PR TITLE
Fix blur in Dolphin settings and properties dialogs

### DIFF
--- a/kstyle/darklyblurhelper.cpp
+++ b/kstyle/darklyblurhelper.cpp
@@ -357,9 +357,20 @@ QRegion BlurHelper::blurSettingsDialogRegion(QWidget *widget) const
 {
     QRegion region;
 
-    // settings only change it for konsole or dolphin about window
-    if ((widget->windowFlags() & Qt::WindowType_Mask) == Qt::Dialog
-        && (widget->inherits("KAboutApplicationDialog") || widget->inherits("KDEPrivate::KAboutKdeDialog"))) {
+    const bool isDialog = (widget->windowFlags() & Qt::WindowType_Mask) == Qt::Dialog;
+    const bool isAboutDialog = widget->inherits("KAboutApplicationDialog") || widget->inherits("KDEPrivate::KAboutKdeDialog");
+
+    if (!isDialog)
+        return region;
+
+    // Dolphin's settings and properties dialogs use translucent window colors,
+    // but they are not KAboutApplicationDialog instances. Request blur for the
+    // dialog's full client area; opaque pixels remain visually unaffected.
+    if (_isDolphin && !isAboutDialog)
+        return roundedRegion(widget->rect(), StyleConfigData::cornerRadius(), false, false, true, true);
+
+    // About dialogs have a separately translucent tab area.
+    if (isAboutDialog) {
         QList<QWidget *> widgets = widget->findChildren<QWidget *>();
         if (widgets.length() > 0) {
             for (auto w : widgets) {


### PR DESCRIPTION
## Summary

- request a blur region for Dolphin settings and properties dialogs
- keep the existing specialized handling for About dialogs unchanged
- limit the new behavior to Dolphin, without changing other applications

## Problem

When Darkly's translucent colors or opacity settings are used, Dolphin's main window is blurred correctly, but its Configure dialog is only transparent. The wallpaper and windows behind it remain sharp.

`blurSettingsDialogRegion()` currently accepts only `KAboutApplicationDialog` and `KDEPrivate::KAboutKdeDialog`, so a normal Dolphin dialog produces no blur region for KWin.

## Change

For non-About dialogs in Dolphin, request blur for the full client area. Opaque pixels remain visually unaffected, while translucent panels receive the expected compositor blur. About dialogs continue through their existing tab-specific path.

## Verification

- reproduced with Plasma 6.6.4 on Wayland and Dolphin 25.12.3
- manually verified that Dolphin's Configure dialog changes from transparency-only to transparency with blur
- built the complete project with both Qt 5 and Qt 6 enabled
- ran all six bundled Qt 5/Qt 6 test executables: 40 passed, 0 failed

Thank you for maintaining Darkly.
