### PR TITLE
fix: use application palette for KMessageWidget corner overlay

### DIFF
--- a/kstyle/darklystyle.cpp
+++ b/kstyle/darklystyle.cpp
@@ -311,7 +311,7 @@ protected:
         : QPalette::Inactive;
 
         QColor outlineColor =
-        parentWidget()->style()->standardPalette().color(group, QPalette::Window);
+        qApp->palette().color(group, QPalette::Window);
 
         painter.setPen(Qt::NoPen);
         painter.setBrush(outlineColor);


### PR DESCRIPTION
## Problem

`RoundedOuterOutlineOverlay` paints the window background color over the rectangular corners of `KMessageWidget` to simulate rounded corners.

It uses `parentWidget()->style()->standardPalette()` to obtain the window background color. However, `QStyle::standardPalette()` returns Qt's **built-in default (light) palette** regardless of the active color scheme. On any dark KColorScheme, this produces visible white/light-colored corners on every `KMessageWidget` (e.g. Dolphin's info bar, Kate's message bar, etc.).

### Before (dark theme)

White corners are visible on the `KMessageWidget` info bar:

The overlay fetches `QPalette::Window` from `standardPalette()`, which is always the Qt default (~white), not the user's dark window background.

## Fix

Switch from `standardPalette()` to `qApp->palette()`, which reflects the palette set by the KDE platform theme (plasma-integration) from `~/.config/kdeglobals`.

This is consistent with how Darkly already obtains the application palette elsewhere in `darklystyle.cpp`:
- Line 4696: `const auto &palette(parent ? parent->palette() : QApplication::palette());`
- Line 8742: `palette = QApplication::palette();`
- Line 8828: `palette = QApplication::palette();`

## Regression analysis

| Scenario | Before (`standardPalette()`) | After (`qApp->palette()`) | Regression? |
|---|---|---|---|
| **Dark KColorScheme** | White corners (bug) | Correct dark corners | ✅ Fixed |
| **Light KColorScheme** | Light corners (correct) | Light corners (correct) | No |
| **Custom app palette** | Ignores customization | Respects customization | No (more correct) |
| **No KDE platform theme** | Default Qt palette | Default Qt palette | No (identical) |
| **Plasma apps** | White corners on dark themes | Correct corners | ✅ Fixed |

The change is a single line: `standardPalette()` → `qApp->palette()`. No new APIs, no behavioral change on light themes.