### PR TITLE
Refinements: Archlinux drop QT5/KF5 dependencies

### DIFF
--- a/.github/assets/pkgbuild/PKGBUILD
+++ b/.github/assets/pkgbuild/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: DeltaCopy <7x0bb03yq@mozmail.com>
 # Description: Builds Darkly from https://github.com/Bali10050/Darkly
 # Used inside Github Action workflow archlinux-ci
+# This package relies on Qt6 and KF6 build dependencies (Qt5 and KF5 dependencies are now dropped)
 
 # basic info
 dev="Bali10050"
@@ -49,13 +50,14 @@ depends_kf5=(
     'kwindowsystem5'
 )
 
-depends=("${depends_kf6[@]}" "${depends_kf5[@]}")
+depends=("${depends_kf6[@]}")
 
 conflicts=(
     lightly-kf6
     lightly-qt
     lightly-qt6
     lightly-qt6-bin
+    darkly
 )
 
 pkgver() {
@@ -72,7 +74,9 @@ build() (
         -B $build_dir
         -S "$pkgname.git"
         -DBUILD_TESTING=OFF
-        -Wno-dev
+        -DBUILD_QT6=ON
+        -DBUILD_QT5=OFF
+        -Wno-author
     )
 
     cmake "${cmake_options[@]}"

--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -24,13 +24,7 @@ jobs:
         run: pacman -Syu --noconfirm
       - name: Install sudo, git and compile dependencies
         run: |
-          pacman -Sy sudo git binutils make gcc pkg-config fakeroot plasma-desktop \
-          cmake extra-cmake-modules qt6-base \
-          kdecoration qt6-declarative kcoreaddons \
-          kcmutils kcolorscheme kconfig kguiaddons \
-          kiconthemes kwindowsystem kcmutils5 \
-          frameworkintegration5 kconfigwidgets5 kiconthemes5 \
-          kirigami2 kwindowsystem5 --noconfirm
+           pacman -Syq base-devel git --noconfirm
       - name: Setup build user
         run: |
           useradd builduser -m # Create the builduser
@@ -49,7 +43,7 @@ jobs:
         run: sudo -u builduser bash -c 'cd /var/tmp/darkly-archlinux; makepkg -g >> PKGBUILD'
       - name: Build package
         run: |
-          sudo -u builduser bash -c 'cd /var/tmp/darkly-archlinux; makepkg -s'
+          sudo -u builduser bash -c 'cd /var/tmp/darkly-archlinux; makepkg -s --noconfirm'
           zst_file=$(find /var/tmp/darkly-archlinux -name "*.zst*")
           publish_filename=darkly-${{ inputs.version }}-x86_64.pkg.zst
           mv "$zst_file" $publish_filename
@@ -60,4 +54,3 @@ jobs:
           name: ${{ env.ARTIFACT }}
           path: ${{ env.ARTIFACT }}
           retention-days: 1
-


### PR DESCRIPTION
Move the builds over to use only Qt6/KF6.
