### PR TITLE
Fix thin outline appearing around Dolphin URL bar even when transparency is enabled

### DIFF
--- a/kstyle/darklyhelper.cpp
+++ b/kstyle/darklyhelper.cpp
@@ -1031,15 +1031,9 @@ void Helper::renderLineEdit(QPainter *painter,
 
             }
 
-            // normal or mouse over
+            // normal
             else {
-                if (mouseOver && !hasFocus)
-                    renderBoxShadow(painter, frameRect, 0, 1, 5, QColor(0, 0, 0, 84), radius, windowActive);
-                else {
-                    renderBoxShadow(painter, frameRect, 0, 1, 5, QColor(0, 0, 0, 84), radius, windowActive);
-                    renderOutline(painter, frameRect, radius, 6);
-                    painter->setPen(Qt::NoPen);
-                }
+                renderBoxShadow(painter, frameRect, 0, 1, 5, QColor(0, 0, 0, 84), radius, windowActive);
             }
         }
     }


### PR DESCRIPTION
When transparency is enabled, a very thin and faint outline becomes visible around the Dolphin URL bar when it is not in edit mode and it is not being hovered, as shown in #351. This fixes that (however it does not address the other problem described in that issue).